### PR TITLE
Add RDRAND to QEMU runner

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner.py
@@ -62,6 +62,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         args += " -machine q35,smm=on" #,accel=(tcg|kvm)"
         args += " -m 2048"
+        args += " -cpu qemu64,+rdrand" # most compatible x64 CPU model + RDRAND support (not included by default)
         #args += " -smp ..."
         args += " -global driver=cfi.pflash01,property=secure,value=on"
         args += " -drive if=pflash,format=raw,unit=0,file=" + \


### PR DESCRIPTION
Many shell based unit tests link to BaseRngLib, which assumes RDRAND support and crashes otherwise, but the default QEMU x64 CPU does not include support for RDRAND.  
This change simply adds RDRAND to the default, most compatible qemu64 CPU.  On my IceLake host, when I attempted alternatives such as IceLake, SkyLake, or even IvyBridge, RDRAND was included and _this_ issue was fixed, but at QEMU invocation, warnings appeared about other instructions that were not supported, either because my hypervisor blocks them, or because my build of QEMU does not include them.  

This is the most compatible and least risky change the resolves this issue.