### PR TITLE
BUG: Temp fix Ubuntu based CI by setting the version to 18.04

### DIFF
--- a/Platforms/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/OvmfPkg/PlatformCI/.azurepipelines/Ubuntu-GCC5.yml
@@ -17,7 +17,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'OvmfPkg'
-      vm_image: 'ubuntu-latest'
+      vm_image: 'ubuntu-18.04'
       should_run: true
       run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
 

--- a/Platforms/QemuQ35Pkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -17,7 +17,7 @@ jobs:
   - job: Platform_CI
     variables:
       package: 'QemuQ35Pkg'
-      vm_image: 'ubuntu-latest'
+      vm_image: 'ubuntu-18.04'
       should_run: true
       run_flags: "MAKE_STARTUP_NSH=TRUE QEMU_HEADLESS=TRUE"
 


### PR DESCRIPTION
In Azure DevOps the Ubuntu-latest pipeline vm was just transitioned to 20.04
Ubuntu 20.04 has a incomplete QEMU package and thus QEMU can not execute using the commands defined for previous versions. 
Temp fix is to force build servers to use 18.04 ubuntu version. 