### PR TITLE
Cherry-Pick: QemuQ35Pkg.dsc: Set UART I/O port to 0x402

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -744,6 +744,7 @@ PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestL
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gPcAtChipsetPkgTokenSpaceGuid.PcdUartIoPortBaseAddress|0x402
 
   # DEBUG_INIT      0x00000001  // Initialization
   # DEBUG_WARN      0x00000002  // Warnings


### PR DESCRIPTION
QemuQ35Pkg uses QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
as the DebugLib instance if DEBUG_ON_SERIAL_PORT is not defined (default behavior),
similar to OvmfPkg. The I/O port value is used from gUefiOvmfPkgTokenSpaceGuid.PcdDebugIoPort
which is set by default to 0x402 in OvmfPkg.dec.

By default, debug messages are written to 0x402. The CpuExceptionHandlerLib instance used
(UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf) links exception
handler output to SerialPortLib, which in the case of QemuQ35Pkg, is
PcAtChipsetPkg/Library/SerialIoLib/SerialIoLib.inf.

The I/O port used in that SerialPortLib instance is specified in
gPcAtChipsetPkgTokenSpaceGuid.PcdUartIoPortBaseAddress, which is currently set to the default
value of 0x3F8. This prevents exception handler output from being written to serial.

This change updates that PCD value to match PcdDebugIoPort (0x402) so output is functional
from exception handlers.