### PR TITLE
Create CODEOWNERS File

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+
+# Ms Core UEFI will be notified for all PRs in this repo.
+* @microsoft/msuefi_admin


### PR DESCRIPTION
CODEOWNERS allows maintainers to be auto-notified of pending PRs