### PR TITLE
OvmfPkg: Uncrustify fixes

### DIFF
--- a/Platforms/OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.c
+++ b/Platforms/OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.c
@@ -658,8 +658,8 @@ InitializeFvAndVariableStoreHeaders (
 
       // UINT32  Size;
       (
-       FixedPcdGet32 (PcdFlashNvStorageVariableSize) -
-       OFFSET_OF (FVB_FV_HDR_AND_VARS_TEMPLATE, VarHdr)
+        FixedPcdGet32 (PcdFlashNvStorageVariableSize) -
+        OFFSET_OF (FVB_FV_HDR_AND_VARS_TEMPLATE, VarHdr)
       ),
 
       // UINT8   Format;

--- a/Platforms/OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.c
+++ b/Platforms/OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.c
@@ -54,12 +54,12 @@ STATIC CONST MMIO64_PREFERENCE  mConfiguration = {
   {
     ACPI_ADDRESS_SPACE_DESCRIPTOR,                 // Desc
     (UINT16)(                                      // Len
-                                                   sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) -
-                                                   OFFSET_OF (
-                                                     EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR,
-                                                     ResType
-                                                     )
-                                                   ),
+      sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) -
+      OFFSET_OF (
+        EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR,
+        ResType
+        )
+      ),
     ACPI_ADDRESS_SPACE_TYPE_MEM,                   // ResType
     0,                                             // GenFlag
     0,                                             // SpecificFlag

--- a/Platforms/OvmfPkg/PlatformPei/MemTypeInfo.c
+++ b/Platforms/OvmfPkg/PlatformPei/MemTypeInfo.c
@@ -196,7 +196,7 @@ OnReadOnlyVariable2Available (
 //
 STATIC CONST EFI_PEI_NOTIFY_DESCRIPTOR  mReadOnlyVariable2Notify = {
   (EFI_PEI_PPI_DESCRIPTOR_NOTIFY_DISPATCH |
-   EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),  // Flags
+    EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST), // Flags
   &gEfiPeiReadOnlyVariable2PpiGuid,         // Guid
   OnReadOnlyVariable2Available              // Notify
 };

--- a/Platforms/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbInfo.c
+++ b/Platforms/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbInfo.c
@@ -75,9 +75,9 @@ EFI_FVB_MEDIA_INFO  mPlatformFvbMediaInfo[] = {
       {
         {
           (FixedPcdGet32 (PcdFlashNvStorageVariableSize) +
-           FixedPcdGet32 (PcdFlashNvStorageFtwWorkingSize) +
-           FixedPcdGet32 (PcdFlashNvStorageFtwSpareSize) +
-           FixedPcdGet32 (PcdOvmfFlashNvStorageEventLogSize)) /
+            FixedPcdGet32 (PcdFlashNvStorageFtwWorkingSize) +
+            FixedPcdGet32 (PcdFlashNvStorageFtwSpareSize) +
+            FixedPcdGet32 (PcdOvmfFlashNvStorageEventLogSize)) /
           FixedPcdGet32 (PcdOvmfFirmwareBlockSize),
           FixedPcdGet32 (PcdOvmfFirmwareBlockSize),
         }


### PR DESCRIPTION
The new uncrustify update 73.0.4 (f0008a9e) made targeted
improvements to formatting in parenthesized expressions. This change
updates some files in OvmfPkg that are impacted by the new formatting
results.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>