### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["new", "bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file this bug!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: "How can we get in touch with you if we need more info?"
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the Bug
+      description: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: "How did you find this bug? Walk us through it step by step."
+      placeholder: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: "A clear and concise description of what you expected to happen."
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Execution Environment
+      description: "List the OS, python version, system environment variables, etc."
+    validations:
+      required: false
+  - type: textarea
+    id: pip
+    attributes:
+      label: Pip packages
+      description: "If python related, run 'python -m pip list' and copy the output here."
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: "Any other additional context about the problem not covered by the above."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature Request
+description: Submit a feature request
+title: "[Feature]: "
+labels: ["new", "enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for suggesting an idea for this project!
+  - type: textarea
+    id: description
+    attributes:
+      label: What does the feature solve?
+      description: "Is your feature request related to a problem?"
+      placeholder: "Ex. I'm always frustrated when..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution
+      description: "A clear and concise description of what you want to happen"
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Have you considered any alternatives?
+      description: "A clear and concise description of any alternative solutions, features, or workarounds you've considered"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: "Any other additional context about the problem not covered by the above."
+    validations:
+      required: false


### PR DESCRIPTION
Add Bug and Feature request issue templates to this repository.

These are the exact same templates used in edk2-pytool-extensions. You can view what it looks like [here](https://github.com/tianocore/edk2-pytool-extensions/issues/new/choose)