### PR TITLE
Fixing pipeline boot for VS and GCC

### DIFF
--- a/Platforms/QemuQ35Pkg/.azurepipelines/Windows-VS.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/Windows-VS.yml
@@ -74,7 +74,7 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         extra_install_step:
-        - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+        - powershell: choco install qemu --version=2022.8.31; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
         extra_artifacts: |

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -620,7 +620,11 @@
 !endif
 
 [LibraryClasses.X64.PEIM]
+!ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib                   |MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+!else
+  DebugLib                   |QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+!endif
   CpuExceptionHandlerLib     |UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
 
 #########################################
@@ -843,6 +847,7 @@ PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestL
   gEfiMdePkgTokenSpaceGuid.PcdReportStatusCodePropertyMask|0x07
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|TRUE
+  gPcAtChipsetPkgTokenSpaceGuid.PcdUartIoPortBaseAddress|0x402
 
   # DEBUG_INIT      0x00000001  // Initialization
   # DEBUG_WARN      0x00000002  // Warnings

--- a/mu_mm_supv_ext_dep.yaml
+++ b/mu_mm_supv_ext_dep.yaml
@@ -9,6 +9,6 @@
   "name": "FEATURE_MM_SUPV",
   "var_name": "FEATURE_MM_SUPV_PATH",
   "source": "https://github.com/microsoft/mu_feature_mm_supv.git",
-  "version": "679423008d6898a57e1e80ffb6eece72cc034058",
+  "version": "78665ab7eae020610426af25ee7e44361e8246e5",
   "flags": ["set_build_var"]
 }


### PR DESCRIPTION
## Description

The current pipeline build boot status indicates various boot failures since supervisor integration.

This change intends to fix them and update the supervisor dependency to top of main branch.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No** - Should just fix the broken changes.

## How This Was Tested

1. Verified VS build on QEMU 6 and 7
2. Verified GCC build on QEMU 4, 6 and 7

## Integration Instructions

N/A

Signed-off-by: Kun Qin <kun.qin@microsoft.com>