### PR TITLE
Reduced the QEMU to run with dual-core by default

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -220,7 +220,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         # Default turn on build reporting.
         self.env.SetValue("BUILDREPORTING", "TRUE", "Enabling build report")
         self.env.SetValue("BUILDREPORT_TYPES", "PCD DEPEX FLASH BUILD_FLAGS LIBRARY FIXED_ADDRESS HASH", "Setting build report types")
-        self.env.SetValue("BLD_*_QEMU_CORE_NUM", "4", "Default")
+        self.env.SetValue("BLD_*_QEMU_CORE_NUM", "1", "Default")
         # Include the MFCI test cert by default, override on the commandline with "BLD_*_SHIP_MODE=TRUE" if you want the retail MFCI cert
         self.env.SetValue("BLD_*_SHIP_MODE", "FALSE", "Default")
         self.__SetEsrtGuidVars("CONF_POLICY_GUID", "6E08E434-8E04-47B5-9A77-78A3A24523EA", "Platform Hardcoded")

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -220,7 +220,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         # Default turn on build reporting.
         self.env.SetValue("BUILDREPORTING", "TRUE", "Enabling build report")
         self.env.SetValue("BUILDREPORT_TYPES", "PCD DEPEX FLASH BUILD_FLAGS LIBRARY FIXED_ADDRESS HASH", "Setting build report types")
-        self.env.SetValue("BLD_*_QEMU_CORE_NUM", "1", "Default")
+        self.env.SetValue("BLD_*_QEMU_CORE_NUM", "2", "Default")
         # Include the MFCI test cert by default, override on the commandline with "BLD_*_SHIP_MODE=TRUE" if you want the retail MFCI cert
         self.env.SetValue("BLD_*_SHIP_MODE", "FALSE", "Default")
         self.__SetEsrtGuidVars("CONF_POLICY_GUID", "6E08E434-8E04-47B5-9A77-78A3A24523EA", "Platform Hardcoded")


### PR DESCRIPTION
## Description

This change reduced the QEMU launcher to start with dual-core boot and build UEFI with dual
core PCD. This should help the pipeline with better control of running time, when assigned with
different types of building agents.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified in test pipelines.

## Integration Instructions

N/A - No developer integration required

Signed-off-by: Kun Qin <kun.qin@microsoft.com>