### PR TITLE
Add CodeQL support to QemuQ35Pkg

### DIFF
--- a/Platforms/QemuQ35Pkg/Docs/Features/feature_codeql.md
+++ b/Platforms/QemuQ35Pkg/Docs/Features/feature_codeql.md
@@ -1,0 +1,96 @@
+# CodeQL
+
+## Overview
+
+CodeQL is open source and free for open-source projects. It is maintained by GitHub and naturally has excellent
+integration with GitHub projects. CodeQL uses a semantic code analysis engine to discover vulnerabilities in a
+number of programming languages (both compiled and interpreted).
+
+[General CodeQL Information](https://codeql.github.com/)
+
+Project Mu (and TianoCore) use CodeQL C/C++ queries to find common programming errors and security vulnerabilities in
+firmware code. This platform leverages the CodeQL build plugin from Mu Basecore that makes it very easy to run CodeQL
+against this platform. You simply use provide the `--codeql` argument in your normal `stuart_update` and `stuart_build`
+commands.
+
+## CodeQL Command-Line Interface (CLI)
+
+Because of CodeQL's integration with GitHub, it is often run in projects hosted on GitHub via an officially supported
+GitHub Action ([codeql-action](https://github.com/github/codeql-action)).
+
+However, a [CodeQL CLI application](https://codeql.github.com/docs/codeql-cli/) is also available that provides a
+command-line interface to CodeQL. This facilitates a local developer workflow by using the CLI application to
+perform two main tasks:
+
+1. Generate a CodeQL database
+2. Analyze the CodeQL database
+
+There's ample documentation written on [creating CodeQL databases](https://codeql.github.com/docs/codeql-cli/creating-codeql-databases/)
+and [analyzing CodeQL databases](https://codeql.github.com/docs/codeql-cli/analyzing-databases-with-the-codeql-cli/).
+
+Our unique firmware build environment poses several challenges and further integrating the CLI with the stuart tool
+set can be daunting for those unfamiliar with stuart's internals.
+
+Therefore, Project Mu and, by extension, this platform, use a set of CodeQL plugins from Mu Basecore to simplify
+CodeQL usage.
+
+## CodeQL Plugins
+
+The CodeQL plugins are described in the [plugin readme](https://github.com/microsoft/mu_basecore/blob/release/202208/.pytool/Plugin/CodeQL/Readme.md).
+This readme does not repeat information and instead focuses on explaining the context of the plugins within this
+platform.
+
+Put simply, the plugins allow a single command-line argument (`--codeql`) to be provided to the normal `stuart`
+commands already used in this platform to run CodeQL.
+
+For example:
+
+- `stuart_update --codeql` - Downloads the appropriate CodeQL CLI for your operating system.
+- `stuart_build --codeql` - Generates a CodeQL database using that CodeQL during the build. In post-build, the
+  database is automatically analyzed and a SARIF file is generated.
+
+Be aware that these commands will take a long time. The CodeQL CLI is several hundred megabytes in size and hooking
+CodeQL into the build (1) forces a clean build (2) adds additional CodeQL database logic, both of which increase
+the overall time of the build.
+
+  > Note: The CodeQL queries run during analysis by default are those in [MuCodeQlQueries.qls](https://github.com/microsoft/mu_basecore/blob/release/202208/.pytool/Plugin/CodeQL/MuCodeQlQueries.qls).
+  >
+  > The CodeQL plugin readme describes how to change the queries run and change how the plugin interprets the results.
+  > It also describes how to view SARIF results conveniently in an IDE such as Visual Studio Code.
+  >
+  > Also by default, this platform shows CodeQL result from those queries but does not fail the build if there are
+  > any errors.
+
+### CodeQL Database and Result Locations
+
+Although the database and result directory locations are documented in the plugin readme, they are repeated here for
+convenience.
+
+---
+
+The CodeQL database is written to a directory unique to the package and target being built:
+
+  `Build/codeql-db-<package>-<target>-<instance>`
+
+For example: `Build/codeql-db-qemuq35pkg-debug-0`
+
+The plugin does not delete or overwrite existing databases, the instance value is simply increased. This is
+because databases are large, take a long time to generate, and are important for reproducing analysis results. The user
+is responsible for deleting database directories when they are no longer needed.
+
+Similarly, analysis results are written to a directory unique to the package and target. For analysis, results are
+stored in individual files so those files are stored in a single directory.
+
+For example, all analysis results for the above package and target will be stored in:
+  `codeql-analysis-qemuq35pkg-debug`
+
+CodeQL results are stored in [SARIF](https://sarifweb.azurewebsites.net/) (Static Analysis Results Interchange Format)
+([CodeQL SARIF documentation](https://codeql.github.com/docs/codeql-cli/sarif-output/)) files. Each SARIF file
+corresponding to a database will be stored in a file with an instance matching the database instance.
+
+For example, the analysis result file for the above database would be stored in this file:
+  `codeql-analysis-qemuq35pkg-debug/codeql-db-qemuq35pkg-debug-0.sarif`
+
+The [SARIF Viewer extension for VS Code](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer)
+can open the .sarif file generated by this plugin and allow you to click links directly to the problem area in source
+files.

--- a/Platforms/QemuQ35Pkg/Docs/QemuQ35_ReadMe.md
+++ b/Platforms/QemuQ35Pkg/Docs/QemuQ35_ReadMe.md
@@ -69,6 +69,19 @@ sample PRM modules are used to demonstrate the feature and show how additional m
 
 [Details](Features/feature_prm.md)
 
+### CodeQL
+
+CodeQL is open source and free for open-source projects. It is maintained by GitHub and naturally has excellent
+integration with GitHub projects. CodeQL uses a semantic code analysis engine to discover vulnerabilities in a
+number of programming languages (both compiled and interpreted).
+
+Project Mu (and TianoCore) use CodeQL C/C++ queries to find common programming errors and security vulnerabilities in
+firmware code. This platform leverages the CodeQL build plugin from Mu Basecore that makes it very easy to run CodeQL
+against this platform. You simply use provide the `--codeql` argument in your normal `stuart_update` and `stuart_build`
+commands.
+
+[Details](Features/feature_codeql.md)
+
 ## Mu Customized Components
 
 ### Modules

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -20,8 +20,8 @@ from edk2toolext.invocables.edk2_platform_build import BuildSettingsManager
 from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubmodule
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
-from edk2toollib.utility_functions import RunCmd, RunPythonScript
-
+from edk2toollib.utility_functions import RunCmd, GetHostInfo
+from typing import Tuple
 
     # ####################################################################################### #
     #                                Common Configuration                                     #
@@ -37,10 +37,45 @@ class CommonPlatform():
     WorkspaceRoot = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     PackagesPath = ("Platforms", "MU_BASECORE", "Common/MU", "Common/MU_TIANO", "Common/MU_OEM_SAMPLE")
 
+    @staticmethod
+    def add_common_command_line_options(parserObj) -> None:
+        """Adds command line options common to settings managers."""
+        parserObj.add_argument('--codeql', dest='codeql', action='store_true', default=False,
+            help="Optional - Produces CodeQL results from the build. See "
+                 "MU_BASECORE/.pytool/Plugin/CodeQL/Readme.md for more information.")
+
+    @staticmethod
+    def retrieve_common_command_line_options(args) -> bool:
+        """Retrieves command line options common to settings managers."""
+        return args.codeql
+
+    @staticmethod
+    def get_active_scopes(codeql_enabled: bool) -> Tuple[str]:
+        """Returns the active scopes for the platform."""
+        active_scopes = CommonPlatform.Scopes
+
+        # Enable the CodeQL plugin if chosen on command line
+        if codeql_enabled:
+            if GetHostInfo().os == "Linux":
+                active_scopes += ("codeql-linux-ext-dep",)
+            else:
+                active_scopes += ("codeql-windows-ext-dep",)
+            active_scopes += ("codeql-build", "codeql-analyze")
+
+        return active_scopes
+
     # ####################################################################################### #
     #                         Configuration for Update & Setup                                #
     # ####################################################################################### #
 class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSettingsManager):
+
+    def AddCommandLineOptions(self, parserObj):
+        """Add command line options to the argparser"""
+        CommonPlatform.add_common_command_line_options(parserObj)
+
+    def RetrieveCommandLineOptions(self, args):
+        """Retrieve command line options from the argparser"""
+        self.codeql = CommonPlatform.retrieve_common_command_line_options(args)
 
     def GetPackagesSupported(self):
         ''' return iterable of edk2 packages supported by this build.
@@ -101,7 +136,7 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
 
     def GetActiveScopes(self):
         ''' return tuple containing scopes that should be active for this process '''
-        return CommonPlatform.Scopes
+        return CommonPlatform.get_active_scopes(self.codeql)
 
     def FilterPackagesToTest(self, changedFilesList: list, potentialPackagesList: list) -> list:
         ''' Filter other cases that this package should be built
@@ -147,7 +182,7 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
     # ####################################################################################### #
     #                         Actual Configuration for Platform Build                         #
     # ####################################################################################### #
-class PlatformBuilder( UefiBuilder, BuildSettingsManager):
+class PlatformBuilder(UefiBuilder, BuildSettingsManager):
     def __init__(self):
         UefiBuilder.__init__(self)
 
@@ -161,11 +196,14 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
             help="Optional - CSV of architecture to build.  IA32,X64 will use IA32 for PEI and "
             "X64 for DXE and is the only valid option for this platform.")
 
+        CommonPlatform.add_common_command_line_options(parserObj)
+
     def RetrieveCommandLineOptions(self, args):
         '''  Retrieve command line options from the argparser '''
         if args.build_arch.upper() != "IA32,X64":
             raise Exception("Invalid Arch Specified.  Please see comments in PlatformBuild.py::PlatformBuilder::AddCommandLineOptions")
 
+        self.codeql = CommonPlatform.retrieve_common_command_line_options(args)
 
     def GetWorkspaceRoot(self):
         ''' get WorkspacePath '''
@@ -183,7 +221,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
 
     def GetActiveScopes(self):
         ''' return tuple containing scopes that should be active for this process '''
-        return CommonPlatform.Scopes
+        return CommonPlatform.get_active_scopes(self.codeql)
 
     def GetName(self):
         ''' Get the name of the repo, platform, or product being build '''
@@ -234,6 +272,10 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         self.env.SetValue("YAML_POLICY_FILE", self.mws.join(self.ws, "QemuQ35Pkg", "PolicyData", "PolicyDataUsb.yaml"), "Platform Hardcoded")
         self.env.SetValue("POLICY_DATA_STRUCT_FOLDER", self.mws.join(self.ws, "QemuQ35Pkg", "Include"), "Platform Defined")
         self.env.SetValue('POLICY_REPORT_FOLDER', self.mws.join(self.ws, "QemuQ35Pkg", "PolicyData"), "Platform Defined")
+
+        # Globally set CodeQL failures to be ignored in this repo.
+        # Note: This has no impact if CodeQL is not active/enabled.
+        self.env.SetValue("STUART_CODEQL_AUDIT_ONLY", "true", "Platform Defined")
 
         return 0
 


### PR DESCRIPTION
This change adds the ability to opt-in to using CodeQl with
QemuQ35Pkg.

The following needs to be done to activate the CodeQL plugin during
the normal stuart commands:
  1. Add `--codeql` to `stuart_update` to download the CodeQL
      application as an external dependency
  3. Add `--codeql` to `stuart_build` to generate a CodeQL
     database during the build and analyze it in post-build.

See the following the following CodeQL markdown file added for more
information:

  Platforms/QemuQ35Pkg/Docs/Features/feature_codeql.md

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>