### PR TITLE
Onboard pipeline for SBSA platform UEFI

### DIFF
--- a/Platforms/QemuQ35Pkg/ConfigDataGfx/ConfigDataGfx.inf
+++ b/Platforms/QemuQ35Pkg/ConfigDataGfx/ConfigDataGfx.inf
@@ -30,6 +30,7 @@
   ConfigBlobBaseLib
   PeimEntryPoint
   PeiServicesLib
+  PrintLib
 
 [Guids]
   gSetupConfigPolicyVariableGuid                # CONSUMES

--- a/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -77,5 +77,9 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         install_tools: false
+        extra_install_step:
+          - script: sudo microdnf --assumeyes install libssl-dev
+            displayName: Install libssl
+            condition: and(gt(variables.pkg_count, 0), succeeded())
         extra_artifacts: |
           **/QEMU_EFI.fd,**/SECURE_FLASH0.fd

--- a/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -78,8 +78,8 @@ jobs:
         run_flags: $(Run.Flags)
         install_tools: false
         extra_install_step:
-          - script: sudo microdnf --assumeyes install libssl-dev
-            displayName: Install libssl
+          - script: sudo microdnf --assumeyes install openssl-devel
+            displayName: Install openssl
             condition: and(gt(variables.pkg_count, 0), succeeded())
         extra_artifacts: |
           **/QEMU_EFI.fd,**/SECURE_FLASH0.fd

--- a/Platforms/QemuSbsaPkg/Library/MsPlatformDevicesLibQemuSbsa/MsPlatformDevicesLib.c
+++ b/Platforms/QemuSbsaPkg/Library/MsPlatformDevicesLibQemuSbsa/MsPlatformDevicesLib.c
@@ -1,7 +1,7 @@
 /** @file
  *MsPlatformDevicesLib  - Device specific library.
 
-Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/Platforms/QemuSbsaPkg/Library/MsPlatformDevicesLibQemuSbsa/MsPlatformDevicesLib.inf
+++ b/Platforms/QemuSbsaPkg/Library/MsPlatformDevicesLibQemuSbsa/MsPlatformDevicesLib.inf
@@ -1,7 +1,7 @@
 ## @file
 # QemuQ35 Ms Platform Devices Library
 #
-# Copyright (C) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -1,5 +1,5 @@
 # @file
-# Script to Build ArmVirtPkg UEFI firmware
+# Script to Build QEMU SBSA Platform UEFI firmware
 #
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -31,7 +31,7 @@ class CommonPlatform():
         for the different parts of stuart
     '''
     PackagesSupported = ("QemuSbsaPkg",)
-    ArchSupported = ("AARCH64")
+    ArchSupported = ("AARCH64",)
     TargetsSupported = ("DEBUG", "RELEASE", "NOOPT")
     Scopes = ('qemusbsa', 'gcc_aarch64_linux', 'edk2-build', 'cibuild', 'setupdata')
     WorkspaceRoot = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -283,6 +283,8 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args += " BL32=" + os.path.join(op_fv, "BL32_AP_MM.fd")
         args += " all fip"
         args += " -j $(nproc)"
+        # Reuse the openssl from CryptoPkg
+        args += " OPENSSL_DIR=" + self.mws.join(self.ws, "CryptoPkg", "Library", "OpensslLib", "openssl")
         ret = RunCmd(cmd, args, workingdir= self.env.GetValue("ARM_TFA_PATH"))
         if ret != 0:
             return ret

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -283,9 +283,6 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args += " BL32=" + os.path.join(op_fv, "BL32_AP_MM.fd")
         args += " all fip"
         args += " -j $(nproc)"
-        # Reuse the openssl from CryptoPkg
-        args += " OPENSSL_DIR=" + self.mws.join(self.ws, "CryptoPkg", "Library", "OpensslLib", "openssl")
-        args += " PLAT_INCLUDES=" + self.mws.join(self.ws, "CryptoPkg", "Library", "Include", "openssl")
         ret = RunCmd(cmd, args, workingdir= self.env.GetValue("ARM_TFA_PATH"))
         if ret != 0:
             return ret

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -285,6 +285,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args += " -j $(nproc)"
         # Reuse the openssl from CryptoPkg
         args += " OPENSSL_DIR=" + self.mws.join(self.ws, "CryptoPkg", "Library", "OpensslLib", "openssl")
+        args += " PLAT_INCLUDES=" + self.mws.join(self.ws, "CryptoPkg", "Library", "Include", "openssl")
         ret = RunCmd(cmd, args, workingdir= self.env.GetValue("ARM_TFA_PATH"))
         if ret != 0:
             return ret


### PR DESCRIPTION
This change intends to fix the issue discovered during the onboarding process of SBSA platform UEFI pipeline.

Specifically, the changes are:
- The supported architectures are updated so that the stuart_setup step can be happy;
- An extra installation step is specified to install openssl before the container is updated;
- A library dependency is fixed in Q35 package under release build;

A few copyrights are also updated to reflect the latest standards.