### PR TITLE
SBSA: fix issue with fixed memory size and increase for OS boot

### DIFF
--- a/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuLib.inf
+++ b/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuLib.inf
@@ -40,13 +40,13 @@
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gArmTokenSpaceGuid.PcdSystemMemorySize
   gArmVirtTokenSpaceGuid.PcdDeviceTreeInitialBaseAddress
+  gArmTokenSpaceGuid.PcdMmBufferBase
 
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFdBaseAddress
   gArmTokenSpaceGuid.PcdFdSize
   gArmTokenSpaceGuid.PcdArmPrimaryCoreMask
   gArmTokenSpaceGuid.PcdArmPrimaryCore
-  gArmTokenSpaceGuid.PcdMmBufferBase
   gArmTokenSpaceGuid.PcdMmBufferSize
 
 [Ppis]

--- a/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
+++ b/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
@@ -86,6 +86,8 @@ SbsaQemuLibConstructor (
   // TODO: This is carved out by the BL31 during DT build up.
   PcdStatus = PcdSet64S (PcdSystemMemorySize, NewSize - PcdGet64 (PcdMmBufferSize));
   ASSERT_RETURN_ERROR (PcdStatus);
+  PcdStatus = PcdSet64S (PcdMmBufferBase, CurBase + NewSize - PcdGet64 (PcdMmBufferSize));
+  ASSERT_RETURN_ERROR (PcdStatus);
 
   return RETURN_SUCCESS;
 }

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -175,7 +175,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         '''  Retrieve command line options from the argparser '''
         if args.build_arch.upper() != "AARCH64":
             raise Exception("Invalid Arch Specified.  Please see comments in PlatformBuild.py::PlatformBuilder::AddCommandLineOptions")
-        
+
         shell_environment.GetBuildVars().SetValue(
             "TARGET_ARCH", args.build_arch.upper(), "From CmdLine")
 

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -51,8 +51,12 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         else:
             logging.critical("Virtual Drive Path Invalid")
 
+        if env.GetValue("PATH_TO_OS") is not None:
+            args += " -m 8192"
+        else:
+            args += " -m 2048"
+
         args += " -machine sbsa-ref" #,accel=(tcg|kvm)"
-        args += " -m 1024"
         args += " -cpu max"
         if env.GetBuildValue ("QEMU_CORE_NUM") is not None:
           args += " -smp " + env.GetBuildValue ("QEMU_CORE_NUM")

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -664,7 +664,6 @@
   #
   # MM Communicate
   #
-  gArmTokenSpaceGuid.PcdMmBufferBase|0x1003FE00000
   gArmTokenSpaceGuid.PcdMmBufferSize|0x200000
 
   #
@@ -842,6 +841,11 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0
 !endif
+
+  #
+  # MM Communicate
+  #
+  gArmTokenSpaceGuid.PcdMmBufferBase|0x1003FE00000
 
 [PcdsDynamicExDefault]
   # Default this to gSetupDataPkgGenericProfileGuid

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -843,7 +843,7 @@
 !endif
 
   #
-  # MM Communicate
+  # MM Communicate. The MM buffer base will be computed and set at runtime to top of memory.
   #
   gArmTokenSpaceGuid.PcdMmBufferBase|0x0
 

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -845,7 +845,7 @@
   #
   # MM Communicate
   #
-  gArmTokenSpaceGuid.PcdMmBufferBase|0x1003FE00000
+  gArmTokenSpaceGuid.PcdMmBufferBase|0x0
 
 [PcdsDynamicExDefault]
   # Default this to gSetupDataPkgGenericProfileGuid

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -845,7 +845,7 @@
   #
   # MM Communicate. The MM buffer base will be computed and set at runtime to top of memory.
   #
-  gArmTokenSpaceGuid.PcdMmBufferBase|0x0
+  gArmTokenSpaceGuid.PcdMmBufferBase
 
 [PcdsDynamicExDefault]
   # Default this to gSetupDataPkgGenericProfileGuid


### PR DESCRIPTION
- Fix issue with MM normal world buffer being at incorrect location with memory other than 1Gb.
- Automatically increase memory to 8Gb when using an OS volume. 