### PR TITLE
QemuRunner.py: Add QEMU monitor connection option

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -116,6 +116,11 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         if serial_port != None:
             args += " -serial tcp:127.0.0.1:" + serial_port + ",server,nowait"
 
+        # Connect the debug monitor to a telnet localhost port
+        monitor_port = env.GetValue("MONITOR_PORT")
+        if monitor_port is not None:
+            args += " -monitor tcp:127.0.0.1:" + monitor_port + ",server,nowait"
+
         # Run QEMU
         #ret = QemuRunner.RunCmd(executable, args,  thread_target=QemuRunner.QemuCmdReader)
         ret = utility_functions.RunCmd(executable, args)

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -89,6 +89,11 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # write messages to stdio
             args += " -serial stdio"
 
+        # Connect the debug monitor to a telnet localhost port
+        monitor_port = env.GetValue("MONITOR_PORT")
+        if monitor_port is not None:
+            args += " -monitor tcp:127.0.0.1:" + monitor_port + ",server,nowait"
+
         # Run QEMU
         #ret = QemuRunner.RunCmd(executable, args,  thread_target=QemuRunner.QemuCmdReader)
         ret = utility_functions.RunCmd(executable, args)


### PR DESCRIPTION
Allows a `MONITOR_PORT` build env variable to be set to specify
a localhost port that should be connected to the QEMU monitor.

This can be useful for debugging at any phase, but especially for
early boot code.

QEMU Monitor commands:
https://qemu-project.gitlab.io/qemu/system/monitor.html

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>