### PR TITLE
Enable Label Sync GitHub Action

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,21 @@
+# This workflow syncs GitHub labels to the common set of labels defined in Mu DevOps.
+#
+# All repos should sync at the same time.
+#   '0 0,12 * * *''
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Sync GitHub Labels
+
+on:
+  schedule:
+    # At minute 0 past hour 0 and 12
+    # https://crontab.guru/#0_0,12_*_*_*
+    - cron: '0 0,12 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@main


### PR DESCRIPTION
## Description

Adds an action to automatically sync labels used in this repository
from a centralized file in Project Mu DevOps.

https://github.com/microsoft/mu_devops

New labels should be added to the `Labels.yml` file in mu_devops.

Repo-specific labels are allowed to be defined. Those can either be
created in a repo-local config YAML file (preferred) or manually
in the "Labels" section of the repo.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

On fork repositories.

## Integration Instructions

Now downstream integration required, only impacts this repo

Repo users should understand label definitions and read instructions
noted in this change regarding how to modify labels in the future.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>