### PR TITLE
Add Test App Execution to Platform CI for VS Builds

### DIFF
--- a/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
@@ -71,7 +71,7 @@ jobs:
         build_file: $(Build.File)
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
-        timeoutInMinutes: 20
+        run_timeout: 20
         install_tools: false
         artifacts_identifier: '$(package) $(tool_chain_tag) $(Build.Target)'
         artifacts_binary: |

--- a/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
@@ -21,7 +21,7 @@ jobs:
       - name: should_run
         value: true
       - name: run_flags
-        value: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE"
+        value: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp.efi RUN_TESTS=TRUE"
 
     # Use matrix to speed up the build process
     strategy:

--- a/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
@@ -71,6 +71,7 @@ jobs:
         build_file: $(Build.File)
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
+        timeoutInMinutes: 20
         install_tools: false
         artifacts_identifier: '$(package) $(tool_chain_tag) $(Build.Target)'
         artifacts_binary: |

--- a/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Ubuntu-GCC5.yml
@@ -21,7 +21,7 @@ jobs:
       - name: should_run
         value: true
       - name: run_flags
-        value: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp.efi RUN_TESTS=TRUE"
+        value: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE"
 
     # Use matrix to speed up the build process
     strategy:
@@ -71,7 +71,6 @@ jobs:
         build_file: $(Build.File)
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
-        run_timeout: 20
         install_tools: false
         artifacts_identifier: '$(package) $(tool_chain_tag) $(Build.Target)'
         artifacts_binary: |

--- a/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Windows-VS.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Windows-VS.yml
@@ -68,7 +68,7 @@ jobs:
         build_file: $(Build.File)
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
-        timeoutInMinutes: 20
+        run_timeout: 20
         extra_install_step:
         - powershell: choco install qemu --version=2022.8.31; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI

--- a/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Windows-VS.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Windows-VS.yml
@@ -68,6 +68,7 @@ jobs:
         build_file: $(Build.File)
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
+        timeoutInMinutes: 20
         extra_install_step:
         - powershell: choco install qemu --version=2022.8.31; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI

--- a/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Windows-VS.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/templates/Job-Windows-VS.yml
@@ -21,7 +21,7 @@ jobs:
       - name: should_run
         value: true
       - name: run_flags
-        value: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE"
+        value: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp.efi RUN_TESTS=TRUE"
 
     #Use matrix to speed up the build process
     strategy:

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -32,6 +32,7 @@ failure_exempt_tests["MorLockFunctionalTestApp.efi"] = datetime.datetime(2022, 2
 failure_exempt_tests["MsWheaEarlyUnitTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
 failure_exempt_tests["VariablePolicyFuncTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
 failure_exempt_tests["DeviceIdTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
+failure_exempt_tests["DxePagingAuditTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
 
 # Allow failure exempt tests to be ignored for 90 days
 FAILURE_EXEMPT_OMISSION_LENGTH = 90*24*60*60
@@ -442,10 +443,11 @@ class UnitTestSupport(object):
                         caseresult = "\t\t\tPASS"
                         level = logging.INFO
                         for result in case:
-                            if result.tag == 'failure' and not ignore_failure:
-                                failure_count += 1
+                            if result.tag == 'failure':
                                 level = logging.ERROR
                                 caseresult = "\t\tFAIL" + " - " + unescape(result.attrib['message'])
+                                if not ignore_failure:
+                                    failure_count += 1
                         logging.log( level, caseresult)
             except Exception as ex:
                 logging.error("Exception trying to read xml." + str(ex))

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -25,14 +25,14 @@ from typing import Tuple
 
 # Declare test whose failure will not return a non-zero exit code
 failure_exempt_tests = {}
-failure_exempt_tests["BaseCryptLibUnitTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
-failure_exempt_tests["BootAuditTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
-failure_exempt_tests["LineParserTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
-failure_exempt_tests["MorLockFunctionalTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
-failure_exempt_tests["MsWheaEarlyUnitTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
-failure_exempt_tests["VariablePolicyFuncTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
-failure_exempt_tests["DeviceIdTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
-failure_exempt_tests["DxePagingAuditTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["BaseCryptLibUnitTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["BootAuditTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["LineParserTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["MorLockFunctionalTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["MsWheaEarlyUnitTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["VariablePolicyFuncTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["DeviceIdTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["DxePagingAuditTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
 
 # Allow failure exempt tests to be ignored for 90 days
 FAILURE_EXEMPT_OMISSION_LENGTH = 90*24*60*60
@@ -422,7 +422,7 @@ class UnitTestSupport(object):
             if (os.path.basename(unit_test) in failure_exempt_tests.keys()):
                 now = datetime.datetime.now()
                 last_ignore_time = failure_exempt_tests[os.path.basename(unit_test)]
-                if (now - last_ignore_time).total_seconds() > FAILURE_EXEMPT_OMISSION_LENGTH:
+                if (now - last_ignore_time).total_seconds() < FAILURE_EXEMPT_OMISSION_LENGTH:
                     logging.info("Ignoring output of " + os.path.basename(unit_test))
                     ignore_failure = True
             xml_result_file = os.path.basename(unit_test)[:-4] + "_JUNIT.XML"

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -25,14 +25,14 @@ from typing import Tuple
 
 # Declare test whose failure will not return a non-zero exit code
 failure_exempt_tests = {}
-failure_exempt_tests["BaseCryptLibUnitTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
-failure_exempt_tests["BootAuditTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
-failure_exempt_tests["LineParserTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
-failure_exempt_tests["MorLockFunctionalTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
-failure_exempt_tests["MsWheaEarlyUnitTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
-failure_exempt_tests["VariablePolicyFuncTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
-failure_exempt_tests["DeviceIdTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
-failure_exempt_tests["DxePagingAuditTestApp.efi"] = datetime.datetime(2022, 2, 1, 0, 0, 0)
+failure_exempt_tests["BaseCryptLibUnitTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["BootAuditTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["LineParserTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["MorLockFunctionalTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["MsWheaEarlyUnitTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["VariablePolicyFuncTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["DeviceIdTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
+failure_exempt_tests["DxePagingAuditTestApp.efi"] = datetime.datetime(2022, 3, 1, 0, 0, 0)
 
 # Allow failure exempt tests to be ignored for 90 days
 FAILURE_EXEMPT_OMISSION_LENGTH = 90*24*60*60

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -354,6 +354,8 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             VirtualDrivePath = self.env.GetValue("VIRTUAL_DRIVE_PATH", os.path.join(output_base, "VirtualDrive"))
             logging.warning("Linux currently isn't supported for the virtual drive. Falling back to an older method")
 
+            test_regex = self.env.GetValue("TEST_REGEX", "")
+
             if run_tests:
                 logging.critical("Linux doesn't support running unit tests due to lack of VHD support")
 

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1267,7 +1267,7 @@
 
   ## Unit Tests
   #
-  ## Powershell script to discover unit tests in a given directory:
+  ## Powershell script to discover unit tests:
   #
   ## Get-ChildItem -Recurse -Force -File | Where-Object {($_.Name -like "*test*") -and ($_.Extension -eq ".inf")} | ^
   ## Where-Object {(Select-String -InputObject $_ -Pattern "MODULE_TYPE\s*=\s*UEFI_APPLICATION")} | ^
@@ -1297,7 +1297,12 @@
     UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.inf
     # UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/App/SmmPagingProtectionsTestApp.inf # NOT APPLICABLE TO Q35
     XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTestApp.inf
-    XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf
+    XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf {
+      <PcdsPatchableInModule>
+        #Turn off Halt on Assert and Print Assert so that libraries can
+        #be tested in more of a release mode environment
+        gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
+    }
     FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
     MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.inf
     CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf
@@ -1318,12 +1323,6 @@
     UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
     UefiTestingPkg/FunctionalSystemTests/ExceptionPersistenceTestApp/ExceptionPersistenceTestApp.inf
     # UefiTestingPkg/FunctionalSystemTests/VarPolicyUnitTestApp/VarPolicyUnitTestApp.inf
-    XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf {
-      <PcdsPatchableInModule>
-        #Turn off Halt on Assert and Print Assert so that libraries can
-        #be tested in more of a release mode environment
-        gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
-    }
     CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf {
       <LibraryClasses>
         BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -297,6 +297,15 @@
   MsNetworkDependencyLib |PcBdsPkg/Library/MsNetworkDependencyLib/MsNetworkDependencyLib.inf # Library that is attached to drivers that require networking.
   !include NetworkPkg/NetworkLibs.dsc.inc
 
+  PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestLibNull/PlatformSmmProtectionsTestLibNull.inf
+  FmpDependencyLib|FmpDevicePkg/Library/FmpDependencyLib/FmpDependencyLib.inf
+  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+
+[LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM, LibraryClasses.common.DXE_CORE, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION, LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.MM_STANDALONE]
+!ifndef $(DEBUG_ON_SERIAL_PORT)
+  DebugLib|QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
+!endif
+
 ##MSCHANGE Begin
 !if $(TOOL_CHAIN_TAG) == VS2019 or $(TOOL_CHAIN_TAG) == VS2022
 [LibraryClasses.X64, LibraryClasses.IA32]
@@ -379,11 +388,11 @@
   CpuExceptionHandlerLib     |UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
   ReportStatusCodeLib        |MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   ExtractGuidedSectionLib    |MdePkg/Library/BaseExtractGuidedSectionLib/BaseExtractGuidedSectionLib.inf
-!ifdef $(DEBUG_ON_SERIAL_PORT)
-  DebugLib                   |MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
-!else
+
+!ifndef $(DEBUG_ON_SERIAL_PORT)
   DebugLib                   |QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformRomDebugLibIoPort.inf
 !endif
+
 !if $(SOURCE_DEBUG_ENABLE) == TRUE
   DebugAgentLib|SourceLevelDebugPkg/Library/DebugAgent/SecPeiDebugAgentLib.inf
 !endif
@@ -408,11 +417,6 @@
   MemoryAllocationLib        |MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   ReportStatusCodeLib        |MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   RngLib                     |MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf
-!ifdef $(DEBUG_ON_SERIAL_PORT)
-  DebugLib                   |MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
-!else
-  DebugLib                   |QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
-!endif
   MemEncryptSevLib           |QemuQ35Pkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
 
 [LibraryClasses.common.PEI_CORE]
@@ -446,11 +450,6 @@
 !endif
 
 [LibraryClasses.X64.PEIM]
-!ifdef $(DEBUG_ON_SERIAL_PORT)
-  DebugLib                   |MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
-!else
-  DebugLib                   |QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
-!endif
   CpuExceptionHandlerLib     |UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
 
 #########################################
@@ -470,11 +469,6 @@
   ReportStatusCodeLib           |MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
   QemuFwCfgS3Lib                |QemuQ35Pkg/Library/QemuFwCfgS3Lib/DxeQemuFwCfgS3LibFwCfg.inf
   MmUnblockMemoryLib            |MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib/MmSupervisorUnblockMemoryLibDxe.inf
-  !ifdef $(DEBUG_ON_SERIAL_PORT)
-    DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
-  !else
-    DebugLib|QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
-  !endif
 
 # Non DXE Core but everything else
 [LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
@@ -507,6 +501,9 @@
 [LibraryClasses.common.UEFI_DRIVER]
   RngLib|MdePkg/Library/DxeRngLib/DxeRngLib.inf
 
+[LibraryClasses.common.UEFI_APPLICATION]
+  CheckHwErrRecHeaderLib|MsWheaPkg/Library/CheckHwErrRecHeaderLib/CheckHwErrRecHeaderLib.inf
+
 [LibraryClasses.common.DXE_DRIVER]
   PlatformBootManagerLib|MsCorePkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
   PlatformBmPrintScLib|QemuQ35Pkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
@@ -537,12 +534,6 @@
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   TimerLib|QemuQ35Pkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
 
-  !ifdef $(DEBUG_ON_SERIAL_PORT)
-    DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
-  !else
-    DebugLib|QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
-  !endif
-
 [LibraryClasses.common.DXE_SMM_DRIVER]
   MemoryAllocationLib|MdePkg/Library/SmmMemoryAllocationLib/SmmMemoryAllocationLib.inf
   SmmMemLib|MdePkg/Library/SmmMemLib/SmmMemLib.inf
@@ -556,8 +547,6 @@
   DebugAgentLib|SourceLevelDebugPkg/Library/DebugAgent/SmmDebugAgentLib.inf
 !endif
 
-PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestLibNull/PlatformSmmProtectionsTestLibNull.inf
-
 [LibraryClasses.common.SMM_CORE]
   SmmCorePlatformHookLib|MdeModulePkg/Library/SmmCorePlatformHookLibNull/SmmCorePlatformHookLibNull.inf
   MemoryAllocationLib|MdeModulePkg/Library/PiSmmCoreMemoryAllocationLib/PiSmmCoreMemoryAllocationLib.inf
@@ -565,11 +554,6 @@ PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestL
   SmmServicesTableLib|MdeModulePkg/Library/PiSmmCoreSmmServicesTableLib/PiSmmCoreSmmServicesTableLib.inf
 
 [LibraryClasses.common.MM_CORE_STANDALONE]
-!ifdef $(DEBUG_ON_SERIAL_PORT)
-  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
-!else
-  DebugLib|QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
-!endif
   TimerLib|QemuQ35Pkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/BaseExtractGuidedSectionLib/BaseExtractGuidedSectionLib.inf
   FvLib|StandaloneMmPkg/Library/FvLib/FvLib.inf
@@ -588,11 +572,6 @@ PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestL
   IhvSmmSaveStateSupervisionLib|MmSupervisorPkg/Library/IhvMmSaveStateSupervisionLib/IhvMmSaveStateSupervisionLib.inf
 
 [LibraryClasses.common.MM_STANDALONE]
-!ifdef $(DEBUG_ON_SERIAL_PORT)
-  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
-!else
-  DebugLib|QemuQ35Pkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
-!endif
   TimerLib|QemuQ35Pkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
   MmServicesTableLib|MmSupervisorPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
@@ -1288,9 +1267,45 @@ PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestL
 
   ## Unit Tests
   !if $(BUILD_UNIT_TESTS) == TRUE
+
+    UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+    AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.inf
+    DfciPkg/UnitTests/DeviceIdTest/DeviceIdTestApp.inf
+    DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciVarLockAuditTestApp.inf
+    MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf
+    MsCorePkg/UnitTests/JsonTest/JsonTestApp.inf
+    MsCorePkg/UnitTests/MathLibUnitTest/MathLibUnitTestApp.inf
+    # MsGraphicsPkg/UnitTests/SpinnerTest/SpinnerTest.inf
+    MsWheaPkg/Test/UnitTests/Library/LibraryClass/CheckHwErrRecHeaderTestApp.inf
+    MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.inf
+    MsWheaPkg/Test/UnitTests/MsWheaReportUnitTestApp/MsWheaReportUnitTestApp.inf
+    UefiTestingPkg/AuditTests/BootAuditTest/UEFI/BootAuditTestApp.inf
+    # UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/DMAIVRSProtectionUnitTestApp.inf
+    UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+    UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
+    UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAuditTestApp.inf
+    UefiTestingPkg/AuditTests/UefiVarLockAudit/UEFI/UefiVarLockAuditTestApp.inf
+    UefiTestingPkg/FunctionalSystemTests/ExceptionPersistenceTestApp/ExceptionPersistenceTestApp.inf
+    UefiTestingPkg/FunctionalSystemTests/MemmapAndMatTestApp/MemmapAndMatTestApp.inf
+    # UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.inf
+    UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/App/SmmPagingProtectionsTestApp.inf
+    XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTestApp.inf
+    XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf
+    FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
+    MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.inf
+    CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf
+    # MdeModulePkg/Application/MpServicesTest/MpServicesTest.inf
+    MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf
+    # MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
+    MdePkg/Test/ShellTest/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf
+    MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestApp.inf
+    MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibTestApp.inf
+    ShellPkg/Application/ShellCTestApp/ShellCTestApp.inf
+    ShellPkg/Application/ShellSortTestApp/ShellSortTestApp.inf
+    UnitTestFrameworkPkg/Library/UnitTestBootLibUsbClass/UnitTestBootLibUsbClass.inf
+    UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
     UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf
     UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf
-    UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
     MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
     UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
     UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
@@ -1307,8 +1322,6 @@ PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestL
         gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
     }
 
-    MsCorePkg/UnitTests/JsonTest/JsonTestApp.inf
-    XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTestApp.inf
     XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf {
       <PcdsPatchableInModule>
         #Turn off Halt on Assert and Print Assert so that libraries can
@@ -1316,10 +1329,6 @@ PlatformSmmProtectionsTestLib|UefiTestingPkg/Library/PlatformSmmProtectionsTestL
         gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
     }
 
-    # MemMap and MAT Test
-    UefiTestingPkg/FunctionalSystemTests/MemmapAndMatTestApp/MemmapAndMatTestApp.inf
-    # MorLock v1 and v2 Test
-    # this fails on QEMU - UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.inf
   !endif
   #########################################
   # SMM Phase modules

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1273,7 +1273,8 @@
   ## Where-Object {(Select-String -InputObject $_ -Pattern "MODULE_TYPE\s*=\s*UEFI_APPLICATION")} | ^
   ## ForEach-Object {$path = $_.FullName -replace '\\','/'; Write-Output $path}
   !if $(BUILD_UNIT_TESTS) == TRUE
-
+  
+    # TEST APPS
     UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
     AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.inf
     DfciPkg/UnitTests/DeviceIdTest/DeviceIdTestApp.inf
@@ -1317,6 +1318,12 @@
     UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
     UefiTestingPkg/FunctionalSystemTests/ExceptionPersistenceTestApp/ExceptionPersistenceTestApp.inf
     # UefiTestingPkg/FunctionalSystemTests/VarPolicyUnitTestApp/VarPolicyUnitTestApp.inf
+    XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf {
+      <PcdsPatchableInModule>
+        #Turn off Halt on Assert and Print Assert so that libraries can
+        #be tested in more of a release mode environment
+        gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
+    }
     CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf {
       <LibraryClasses>
         BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
@@ -1328,12 +1335,13 @@
         gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
     }
 
-    XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf {
-      <PcdsPatchableInModule>
-        #Turn off Halt on Assert and Print Assert so that libraries can
-        #be tested in more of a release mode environment
-        gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
-    }
+    # OTHER TESTS
+    UnitTestFrameworkPkg/Library/UnitTestBootLibUsbClass/UnitTestBootLibUsbClass.inf
+    UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
+    UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf
+    UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf
+    MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
+    UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
 
   !endif
   #########################################

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1266,46 +1266,52 @@
   SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
 
   ## Unit Tests
+  #
+  ## Powershell script to discover unit tests in a given directory:
+  #
+  ## Get-ChildItem -Recurse -Force -File | Where-Object {($_.Name -like "*test*") -and ($_.Extension -eq ".inf")} | ^
+  ## Where-Object {(Select-String -InputObject $_ -Pattern "MODULE_TYPE\s*=\s*UEFI_APPLICATION")} | ^
+  ## ForEach-Object {$path = $_.FullName -replace '\\','/'; Write-Output $path}
   !if $(BUILD_UNIT_TESTS) == TRUE
 
     UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
     AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.inf
     DfciPkg/UnitTests/DeviceIdTest/DeviceIdTestApp.inf
-    DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciVarLockAuditTestApp.inf
+    # DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciVarLockAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
     MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf
     MsCorePkg/UnitTests/JsonTest/JsonTestApp.inf
     MsCorePkg/UnitTests/MathLibUnitTest/MathLibUnitTestApp.inf
-    # MsGraphicsPkg/UnitTests/SpinnerTest/SpinnerTest.inf
+    # MsGraphicsPkg/UnitTests/SpinnerTest/SpinnerTest.inf # DOESN'T PRODUCE OUTPUT
     MsWheaPkg/Test/UnitTests/Library/LibraryClass/CheckHwErrRecHeaderTestApp.inf
     MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.inf
     MsWheaPkg/Test/UnitTests/MsWheaReportUnitTestApp/MsWheaReportUnitTestApp.inf
     UefiTestingPkg/AuditTests/BootAuditTest/UEFI/BootAuditTestApp.inf
-    # UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/DMAIVRSProtectionUnitTestApp.inf
+    # UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/DMAIVRSProtectionUnitTestApp.inf # NOT APPLICABLE TO Q35
     UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
-    UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf
-    UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAuditTestApp.inf
-    UefiTestingPkg/AuditTests/UefiVarLockAudit/UEFI/UefiVarLockAuditTestApp.inf
+    # UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+    # UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+    # UefiTestingPkg/AuditTests/UefiVarLockAudit/UEFI/UefiVarLockAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
     UefiTestingPkg/FunctionalSystemTests/ExceptionPersistenceTestApp/ExceptionPersistenceTestApp.inf
     UefiTestingPkg/FunctionalSystemTests/MemmapAndMatTestApp/MemmapAndMatTestApp.inf
-    # UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.inf
-    UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/App/SmmPagingProtectionsTestApp.inf
+    UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.inf
+    # UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/App/SmmPagingProtectionsTestApp.inf # NOT APPLICABLE TO Q35
     XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTestApp.inf
     XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf
     FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
     MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.inf
     CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf
     # MdeModulePkg/Application/MpServicesTest/MpServicesTest.inf
-    MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf
-    # MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
+    # MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+    MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
     MdePkg/Test/ShellTest/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf
     MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestApp.inf
     MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibTestApp.inf
-    ShellPkg/Application/ShellCTestApp/ShellCTestApp.inf
-    ShellPkg/Application/ShellSortTestApp/ShellSortTestApp.inf
+    # ShellPkg/Application/ShellCTestApp/ShellCTestApp.inf # DOESN'T PRODUCE OUTPUT
+    # ShellPkg/Application/ShellSortTestApp/ShellSortTestApp.inf # DOESN'T PRODUCE OUTPUT
     UnitTestFrameworkPkg/Library/UnitTestBootLibUsbClass/UnitTestBootLibUsbClass.inf
     UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
-    UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf
-    UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf
+    # UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf # NOT APPLICABLE TO Q35
+    # UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf # NOT APPLICABLE TO Q35
     MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
     UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
     UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1309,7 +1309,7 @@
     # MdeModulePkg/Application/MpServicesTest/MpServicesTest.inf
     # MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
     MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
-    MdePkg/Test/ShellTest/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf
+    # MdePkg/Test/ShellTest/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf # TEST IS MOVING TO MU_PLUS
     MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestApp.inf
     MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibTestApp.inf
     # ShellPkg/Application/ShellCTestApp/ShellCTestApp.inf # DOESN'T PRODUCE OUTPUT


### PR DESCRIPTION
## Description

To increase confidence in submodule updates, this PR adds the requirement that test apps included in the Q35 DSC successfully run during CI.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested in azure pipelines.

## Integration Instructions

N/A
