### PR TITLE
QemuRunner.py: Allow OS image paths with spaces

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -82,7 +82,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         if env.GetValue("PATH_TO_OS") is not None:
             # Potentially dealing with big daddy, give it more juice...
             args += " -m 8192"
-            args += " -hda " + env.GetValue("PATH_TO_OS")
+            args += " -hda \"" + env.GetValue("PATH_TO_OS") + "\""
         else:
             args += " -m 2048"
         args += " -cpu qemu64,+rdrand,umip,+smep" # most compatible x64 CPU model + RDRAND + UMIP + SMEP support (not included by default)

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -43,7 +43,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args = "-net none"
         # Mount disk with either startup.nsh or OS image
         if env.GetValue("PATH_TO_OS") is not None:
-            args += " -hda " + env.GetValue("PATH_TO_OS")
+            args += " -hda \"" + env.GetValue("PATH_TO_OS") + "\""
         elif os.path.isfile(VirtualDrive):
             args += f" -hdd {VirtualDrive}"
         elif os.path.isdir(VirtualDrive):


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Wraps the `-hda` path given to QEMU with quotes so it can contain spaces.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with paths to OS images that include spaces in the path.

## Integration Instructions

N/A