### PR TITLE
bump edk2-pytool-library and MU_BASECORE submodule

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.12.1 
+edk2-pytool-library==0.13.0 
 edk2-pytool-extensions==0.21.1
 xmlschema==2.1.1
 regex==2022.10.31


### PR DESCRIPTION
## Description

Bumps the version of edk2-pytool-library and the MU_BASECORE submodule as there is an integration task to upgrade both MU_BASECORE submodule and edk2-pytool-library at the same time.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

passing CI

## Integration Instructions

N/A
