### PR TITLE
Updated crypto logic to work correctly

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -300,9 +300,7 @@
   !include NetworkPkg/NetworkLibs.dsc.inc
 
 #SHARED_CRYPTO
-!if $(ENABLE_SHARED_CRYPTO) == TRUE
-  #!include CryptoPkg/Driver/Bin/CryptoDriver.inc.dsc
-!else
+!if $(ENABLE_SHARED_CRYPTO) == FALSE
   [LibraryClasses.IA32]
     BaseCryptLib|CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.inf
     TlsLib|CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.inf
@@ -425,7 +423,6 @@
   QemuFwCfgS3Lib             |QemuQ35Pkg/Library/QemuFwCfgS3Lib/PeiQemuFwCfgS3LibFwCfg.inf
   PcdLib                     |MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   QemuFwCfgLib               |QemuQ35Pkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
-  #BaseCryptLib               |CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
   PcdDatabaseLoaderLib       |MdeModulePkg/Library/PcdDatabaseLoaderLib/Pei/PcdDatabaseLoaderLibPei.inf
   OemMfciLib                 |OemPkg/Library/OemMfciLib/OemMfciLibPei.inf
 !if $(SOURCE_DEBUG_ENABLE) == TRUE
@@ -492,7 +489,6 @@
   ResetSystemLib|QemuQ35Pkg/Library/ResetSystemLib/DxeResetSystemLib.inf
   HwResetSystemLib|QemuQ35Pkg/Library/ResetSystemLib/DxeResetSystemLib.inf
   UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
-  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
 
 [LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.DXE_DRIVER]

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -507,7 +507,7 @@ INF  SetupDataPkg/ConfProfileMgrDxe/ConfProfileMgrDxe.inf
   !include CryptoPkg/Driver/Bin/CryptoDriver.DXE.inc.fdf
 !else
   INF  CryptoPkg/Driver/CryptoDxe.inf
-  #INF  CryptoPkg/Driver/CryptoSmm.inf
+  INF  CryptoPkg/Driver/CryptoSmm.inf
 !endif
 
 !if $(BUILD_UNIT_TESTS) == TRUE


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The shared crypto and non-shared crypto were both set up incorrectly for Qemu.  This fixes that within the platform dsc and fdf files.  This also fixes the BaseCryptoUnitTestApp shell test as well.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Build and booted to the shell and had all the crypto tests passing with both shared and non-shared crypto.

## Integration Instructions

Nothing necessary.
