### PR TITLE
.azurepipelines: Update for mu_devops 2.0.0 changes

### DIFF
--- a/Platforms/QemuQ35Pkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -77,5 +77,6 @@ jobs:
         build_flags: $(Build.Flags)
         run_flags: $(Run.Flags)
         install_tools: false
-        extra_artifacts: |
+        artifacts_identifier: '$(package) $(Build.Target)'
+        artifacts_binary: |
           **/QEMUQ35_*.fd

--- a/Platforms/QemuQ35Pkg/.azurepipelines/Windows-VS.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/Windows-VS.yml
@@ -77,6 +77,7 @@ jobs:
         - powershell: choco install qemu --version=2022.8.31; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
-        extra_artifacts: |
+        artifacts_identifier: '$(package) $(Build.Target)'
+        artifacts_binary: |
           **/QEMUQ35_*.fd
 

--- a/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -81,6 +81,7 @@ jobs:
           - script: sudo microdnf --assumeyes install openssl-devel
             displayName: Install openssl
             condition: and(gt(variables.pkg_count, 0), succeeded())
-        extra_artifacts: |
+        artifacts_identifier: '$(package) $(Build.Target)'
+        artifacts_binary: |
           **/QEMU_EFI.fd
           **/SECURE_FLASH0.fd


### PR DESCRIPTION
Fixes #289 

## Description

The YAML files in this change depend on `main` in mu_devops instead
of a fixed version.

mu_devops recently moved to a new major release (`2.0.0`):
https://github.com/microsoft/mu_devops/releases/tag/v2.0.0

It was a major release because it contains a breaking change in
template parameters. Therefore, the pipelines that use these
YAML files broke.

This change fixes the pipelines.

Decision whether to sync with a fixed version of mu_devops (like
other YAML files) or stay like this can be made outside this change.

---

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

PR gates.

## Integration Instructions

N/A - Fixes plat pipelines

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>