### PR TITLE
Bump Fedora-35 test container image to `5b8a008`

### DIFF
--- a/Platforms/QemuQ35Pkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuQ35Pkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -62,7 +62,7 @@ jobs:
     pool:
       vmImage: $(vm_image)
 
-    container: ghcr.io/tianocore/containers/fedora-35-test:5800d58
+    container: ghcr.io/tianocore/containers/fedora-35-test:5b8a008
 
     steps:
     - script: echo "##vso[task.prependpath]/home/vsts_azpcontainer/.local/bin"

--- a/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -78,7 +78,7 @@ jobs:
         run_flags: $(Run.Flags)
         install_tools: false
         extra_install_step:
-          - script: sudo microdnf --assumeyes install openssl-devel
+          - script: sudo dnf --assumeyes install openssl-devel
             displayName: Install openssl
             condition: and(gt(variables.pkg_count, 0), succeeded())
         artifacts_identifier: '$(package) $(Build.Target)'

--- a/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
+++ b/Platforms/QemuSbsaPkg/.azurepipelines/Ubuntu-GCC5.yml
@@ -62,7 +62,7 @@ jobs:
     pool:
       vmImage: $(vm_image)
 
-    container: ghcr.io/tianocore/containers/fedora-35-test:5800d58
+    container: ghcr.io/tianocore/containers/fedora-35-test:5b8a008
 
     steps:
     - script: echo "##vso[task.prependpath]/home/vsts_azpcontainer/.local/bin"


### PR DESCRIPTION
## Description

Bump Fedora-35 test container image to `5b8a008`
The Ubuntu YAML files in `QemuQ35Pkg` and `QemuSbsaPkg` specify the
test container image to use.

Update from `5800d58` to `5b8a008`

More info about the new image:
https://github.com/tianocore/containers/pkgs/container/containers%2Ffedora-35-test/67235799?tag=5b8a008

Differences from the old image to new image:
https://github.com/tianocore/containers/compare/5800d58..5b8a008

In particular, introduces powershell support and .NET fixes for unit
tests and code coverage flows.

---

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

PR gates.

## Integration Instructions

N/A - Impacts Ubuntu pipelines

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>