### PR TITLE
.gitmodules: Add default tracking branch for MU_FEATURE_DFCI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,4 @@
 [submodule "Common/MU_FEATURE_DFCI"]
 	path = Common/MU_FEATURE_DFCI
 	url = https://github.com/microsoft/mu_feature_dfci.git
+	branch = main


### PR DESCRIPTION
## Description

Updates the submodule entry to contain a tracking branch to the
primary branch (`main`) in the repo.

This aligns with the configuration used for other submodules in
the repo and allows the following command to be used to quickly
update the submodule to the latest commit on the `main` branch.

  `git submodule update --remote MU_FEATURE_DFCI`

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Confirmed change in .gitmodules file and ran the following command
to test updating the DFCI module from the remote tracking branch:

`git submodule update --remote MU_FEATURE_DFCI`

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>