### PR TITLE
QemuQ35Pkg: Fix broken link in building.md

### DIFF
--- a/Platforms/QemuQ35Pkg/Docs/Development/building.md
+++ b/Platforms/QemuQ35Pkg/Docs/Development/building.md
@@ -130,5 +130,5 @@ command-line would be:
 
 ## References
 
-- [Installing and using Pytools](https://github.com/tianocore/edk2-pytool-extensions/blob/master/docs/using.md#installing)
+- [Installing and using Pytools](https://www.tianocore.org/edk2-pytool-extensions/using/install/)
 - More on [python virtual environments](https://docs.python.org/3/library/venv.html)


### PR DESCRIPTION
## Description

fix broken link.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Check doc link by hand.

## Integration Instructions
N/A
