### PR TITLE
.pytool/CISettings: Return all package paths

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -169,12 +169,9 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         ''' Return a list of workspace relative paths that should be mapped as edk2 PackagesPath '''
 
         # Include all submodule paths
-        result = []
+        result = ["Platforms"]
         for submodule in self.GetRequiredSubmodules():
             result.append(submodule.path)
-
-        # Include platform packages
-        result.append("Platforms")
 
         return result
 

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -167,7 +167,15 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
 
     def GetPackagesPath(self):
         ''' Return a list of workspace relative paths that should be mapped as edk2 PackagesPath '''
-        result = ["Platforms", "MU_BASECORE", "Common/MU", "Common/MU_TIANO", "Common/MU_OEM_SAMPLE"]
+
+        # Include all submodule paths
+        result = []
+        for submodule in self.GetRequiredSubmodules():
+            result.append(submodule.path)
+
+        # Include platform packages
+        result.append("Platforms")
+
         return result
 
     def GetWorkspaceRoot(self):


### PR DESCRIPTION
## Description

While only the `NO-TARGET` and `NOOPT` targets are active in the CI
settings file, plugins active for those targets can depend on the
package paths to accurately represent the workspace.

Current package paths returned in `GetPackagesPath()`:

- Platforms
- MU_BASECORE
- Common/MU_TIANO
- Common/MU
- Common/MU_OEM_SAMPLE

Current submodules returned in `GetRequiredSubmodules()`:

- MU_BASECORE
- Common/MU_TIANO
- Common/MU
- Common/MU_OEM_SAMPLE
- Silicon/Arm/MU_TIANO
- Silicon/Arm/TFA
- Features/DFCI
- Features/CONFIG
- Features/MM_SUPV

A more complete and accurate list of package paths can be maintained
over time by simply using the submodule list + the `Platforms`
directory.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

PR gates.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>