### PR TITLE
[REBASE && FF] Add Support for Virtual Drive Testing on Linux

### DIFF
--- a/.azurepipelines/Platform-Build-Job.yml
+++ b/.azurepipelines/Platform-Build-Job.yml
@@ -96,6 +96,8 @@ jobs:
     - ${{ if and(ne(parameters.container_image, ''), not(contains(parameters.vm_image, 'windows'))) }}:
       - script: echo "##vso[task.prependpath]/home/vsts_azpcontainer/.local/bin"
         displayName: Add User Local Bin to Path
+      - script: sudo dnf install -y mtools dosfstools
+        displayName: Install mtools and dosfstools
     - template: Steps/BuildPlatform.yml@mu_devops
       parameters:
         tool_chain_tag: $(tool_chain_tag)

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -13,6 +13,7 @@ import datetime
 import xml.etree.ElementTree
 import tempfile
 import uuid
+import string
 
 from edk2toolext.environment import shell_environment
 from edk2toolext.environment.uefi_build import UefiBuilder
@@ -314,60 +315,43 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         output_base = self.env.GetValue("BUILD_OUTPUT_BASE")
         shutdown_after_run = (self.env.GetValue("SHUTDOWN_AFTER_RUN", "FALSE").upper() == "TRUE")
         empty_drive = (self.env.GetValue("EMPTY_DRIVE", "FALSE").upper() == "TRUE")
+        test_regex = self.env.GetValue("TEST_REGEX", "")
 
         if os.name == 'nt':
             VirtualDrivePath = self.env.GetValue("VIRTUAL_DRIVE_PATH", os.path.join(output_base, "VirtualDrive.vhd"))
-            VirtualDrive = VirtualDriveManager(VirtualDrivePath, self.env)
-            self.env.SetValue("VIRTUAL_DRIVE_PATH", VirtualDrivePath, "Set Virtual Drive path in case not set")
-            ut = UnitTestSupport(os.path.join(output_base, "X64"))
-
-            if empty_drive and os.path.isfile(VirtualDrivePath):
-                    os.remove(VirtualDrivePath)
-
-            if not os.path.isfile(VirtualDrivePath):
-                VirtualDrive.MakeDrive()
-
-            test_regex = self.env.GetValue("TEST_REGEX", "")
-
-            if test_regex != "":
-                ut.set_test_regex(test_regex)
-                ut.find_tests()
-                ut.copy_tests_to_virtual_drive(VirtualDrive)
-
-            if run_tests:
-                if test_regex == "":
-                    logging.warning("No tests specified using TEST_REGEX flag but RUN_TESTS is TRUE")
-                elif not empty_drive:
-                    logging.info("EMPTY_DRIVE=FALSE. This could impact your test results")
-
-                if not shutdown_after_run:
-                    logging.info("SHUTDOWN_AFTER_RUN=FALSE (default). XML test results will not be \
-                        displayed until after the QEMU instance ends")
-                ut.write_tests_to_startup_nsh(startup_nsh)
-
-            nshpath = os.path.join(output_base, "startup.nsh")
-            startup_nsh.WriteOut(nshpath, shutdown_after_run)
-
-            VirtualDrive.AddFile(nshpath)
-
+            VirtualDrive = WindowsVirtualDriveManager(VirtualDrivePath, self.env)
         else:
-            VirtualDrivePath = self.env.GetValue("VIRTUAL_DRIVE_PATH", os.path.join(output_base, "VirtualDrive"))
-            logging.warning("Linux currently isn't supported for the virtual drive. Falling back to an older method")
+            VirtualDrivePath = self.env.GetValue("VIRTUAL_DRIVE_PATH", os.path.join(output_base, "VirtualDrive.img"))
+            VirtualDrive = LinuxVirtualDriveManager (VirtualDrivePath)
 
-            test_regex = self.env.GetValue("TEST_REGEX", "")
+        self.env.SetValue("VIRTUAL_DRIVE_PATH", VirtualDrivePath, "Set Virtual Drive path in case not set")
 
-            if run_tests:
-                logging.critical("Linux doesn't support running unit tests due to lack of VHD support")
+        if empty_drive and os.path.isfile(VirtualDrivePath):
+            os.remove(VirtualDrivePath)
 
-            if os.path.exists(VirtualDrivePath) and empty_drive:
-                shutil.rmtree(VirtualDrivePath)
+        if not os.path.isfile(VirtualDrivePath):
+            VirtualDrive.MakeDrive()
 
-            if not os.path.exists(VirtualDrivePath):
-                os.makedirs(VirtualDrivePath)
+        ut = UnitTestSupport(os.path.join(output_base, "X64"))
+        if test_regex != "":
+            ut.set_test_regex(test_regex)
+            ut.find_tests()
+            ut.copy_tests_to_virtual_drive(VirtualDrive)
 
-            nshpath = os.path.join(VirtualDrivePath, "startup.nsh")
-            self.env.SetValue("VIRTUAL_DRIVE_PATH", VirtualDrivePath, "Set Virtual Drive path in case not set")
-            startup_nsh.WriteOut(nshpath, shutdown_after_run)
+        if run_tests:
+            if test_regex == "":
+                logging.warning("No tests specified using TEST_REGEX flag but RUN_TESTS is TRUE")
+            elif not empty_drive:
+                logging.info("EMPTY_DRIVE=FALSE. This could impact your test results")
+
+            if not shutdown_after_run:
+                logging.info("SHUTDOWN_AFTER_RUN=FALSE (default). XML test results will not be \
+                    displayed until after the QEMU instance ends")
+            ut.write_tests_to_startup_nsh(startup_nsh)
+
+        nshpath = os.path.join(output_base, "startup.nsh")
+        startup_nsh.WriteOut(nshpath, shutdown_after_run)
+        VirtualDrive.AddFile(nshpath)
 
         ret = self.Helper.QemuRun(self.env)
         if ret != 0:
@@ -375,7 +359,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             return ret
 
         failures = 0
-        if run_tests and os.name == 'nt':
+        if run_tests:
             failures = ut.report_results(VirtualDrive)
 
         # do stuff with unit test results here
@@ -412,7 +396,7 @@ class UnitTestSupport(object):
     def report_results(self, virtualdrive) -> int:
         from html import unescape
 
-        report_folder_path = os.path.join(os.path.dirname(virtualdrive.path_to_vhd), "unit_test_results")
+        report_folder_path = os.path.join(os.path.dirname(virtualdrive.drive_path), "unit_test_results")
         os.makedirs(report_folder_path, exist_ok=True)
         #now parse the xml for errors
         failure_count = 0
@@ -458,19 +442,19 @@ class UnitTestSupport(object):
 
 
 
-class VirtualDriveManager(object):
+class WindowsVirtualDriveManager(object):
 
     def __init__(self, vhd_path:os.PathLike, env:object):
-        self.path_to_vhd = os.path.abspath(vhd_path)
+        self.drive_path = os.path.abspath(vhd_path)
         self._env = env
 
     def MakeDrive(self, size: int=60):
-        ret = RunCmd("VHDCreate", f'-sz {size}MB {self.path_to_vhd}')
+        ret = RunCmd("VHDCreate", f'-sz {size}MB {self.drive_path}')
         if ret != 0:
             logging.error("Failed to create VHD")
             return ret
 
-        ret = RunCmd("DiskFormat", f"-ft fat -ptt bios {self.path_to_vhd}")
+        ret = RunCmd("DiskFormat", f"-ft fat -ptt bios {self.drive_path}")
         if ret != 0:
             logging.error("Failed to format VHD")
             return ret
@@ -478,7 +462,7 @@ class VirtualDriveManager(object):
 
     def AddFile(self, HostFilePath:os.PathLike):
         file_name = os.path.basename(HostFilePath)
-        ret = RunCmd("FileInsert", f"{HostFilePath} {file_name} {self.path_to_vhd}")
+        ret = RunCmd("FileInsert", f"{HostFilePath} {file_name} {self.drive_path}")
         return ret
 
     def GetFileContent(self, VirtualFilePath, HostFilePath: os.PathLike=None):
@@ -493,9 +477,63 @@ class VirtualDriveManager(object):
             return f.read()
 
     def ExtractFile(self, VirtualFilePath, HostFilePath:os.PathLike):
-        ret = RunCmd("FileExtract", f"{VirtualFilePath} {HostFilePath} {self.path_to_vhd}")
+        ret = RunCmd("FileExtract", f"{VirtualFilePath} {HostFilePath} {self.drive_path}")
         return ret
 
+class LinuxVirtualDriveManager(object):
+
+    def __init__(self, img_path:os.PathLike):
+        self.drive_path = os.path.abspath(img_path)
+        self.drive_letter = self.find_unused_drive_letter()
+
+    def find_unused_drive_letter(self):
+        for drive_letter in string.ascii_lowercase:
+            mtab_content = os.popen(f"grep -i '/mnt/{drive_letter} ' /etc/mtab").read()
+            if mtab_content:
+                continue
+            return drive_letter
+
+        raise ValueError("No unused drive letters available")
+
+    def MakeDrive(self, size: int=60):
+        # Create an image
+        ret = RunCmd("dd", f"if=/dev/zero of={self.drive_path} bs=1M count={size}")
+        if ret != 0:
+            logging.error("Failed to create IMG")
+            return ret
+        
+        # Format the image as FAT32
+        ret = RunCmd("mkfs.vfat", f"{self.drive_path}")
+        if ret != 0:
+            logging.error("Failed to format IMG")
+            return ret
+        
+        # Create an mtools config file to virtually map the image to a drive letter
+        RunCmd("echo", "mtools_skip_check=1 > ~/.mtoolsrc")
+        RunCmd("echo", f"drive {self.drive_letter}: >> ~/.mtoolsrc")
+        RunCmd("echo", f"\"  file=\\\"{self.drive_path}\\\" exclusive\" >> ~/.mtoolsrc")
+
+        return 0
+
+    def AddFile(self, HostFilePath:os.PathLike):
+        ret = RunCmd("mcopy", f"-n -i {self.drive_path} {HostFilePath} {self.drive_letter}:")
+        return ret
+
+    def GetFileContent(self, VirtualFilePath, HostFilePath: os.PathLike=None):
+        temp_extract_path = HostFilePath
+        if temp_extract_path == None:
+            temp_extract_path = tempfile.mktemp()
+        logging.info(f"Extracting {VirtualFilePath} to {temp_extract_path}")
+        full_path = os.path.join(self.drive_letter + ":", VirtualFilePath)
+        ret = self.ExtractFile(full_path, temp_extract_path)
+        if ret != 0:
+            raise FileNotFoundError(VirtualFilePath)
+        with open(temp_extract_path, "rb") as f:
+            return f.read()
+
+    def ExtractFile(self, VirtualFilePath, HostFilePath:os.PathLike):
+        ret = RunCmd("mcopy", f"-n -i {self.drive_path} {VirtualFilePath} {HostFilePath}")
+        return ret
 
 class StartUpScriptManager(object):
 

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -26,7 +26,6 @@ from typing import Tuple
 
 # Declare test whose failure will not return a non-zero exit code
 failure_exempt_tests = {}
-failure_exempt_tests["BaseCryptLibUnitTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
 failure_exempt_tests["BootAuditTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
 failure_exempt_tests["LineParserTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
 failure_exempt_tests["MorLockFunctionalTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
@@ -34,6 +33,8 @@ failure_exempt_tests["MsWheaEarlyUnitTestApp.efi"] = datetime.datetime(2023, 3, 
 failure_exempt_tests["VariablePolicyFuncTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
 failure_exempt_tests["DeviceIdTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
 failure_exempt_tests["DxePagingAuditTestApp.efi"] = datetime.datetime(2023, 3, 7, 0, 0, 0)
+failure_exempt_tests["MemoryProtectionTestApp.efi"] = datetime.datetime(2023, 4, 5, 0, 0, 0)
+failure_exempt_tests["MemoryAttributeProtocolFuncTestApp.efi"] = datetime.datetime(2023, 4, 5, 0, 0, 0)
 
 # Allow failure exempt tests to be ignored for 90 days
 FAILURE_EXEMPT_OMISSION_LENGTH = 90*24*60*60

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1264,84 +1264,70 @@
   MsGraphicsPkg/PrintScreenLogger/PrintScreenLogger.inf
   SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
 
-  ## Unit Tests
-  #
-  ## Powershell script to discover unit tests:
-  #
-  ## Get-ChildItem -Recurse -Force -File | Where-Object {($_.Name -like "*test*") -and ($_.Extension -eq ".inf")} | ^
-  ## Where-Object {(Select-String -InputObject $_ -Pattern "MODULE_TYPE\s*=\s*UEFI_APPLICATION")} | ^
-  ## ForEach-Object {$path = $_.FullName -replace '\\','/'; Write-Output $path}
-  !if $(BUILD_UNIT_TESTS) == TRUE
+## Unit Tests
+#
+## Powershell script to discover unit tests:
+#
+## Get-ChildItem -Recurse -Force -File | Where-Object {($_.Name -like "*test*") -and ($_.Extension -eq ".inf")} | ^
+## Where-Object {(Select-String -InputObject $_ -Pattern "MODULE_TYPE\s*=\s*UEFI_APPLICATION")} | ^
+## ForEach-Object {$path = $_.FullName -replace '\\','/'; Write-Output $path}
+!if $(BUILD_UNIT_TESTS) == TRUE
 
-    # TEST APPS
-    UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
-    AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.inf
-    DfciPkg/UnitTests/DeviceIdTest/DeviceIdTestApp.inf
-    # DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciVarLockAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
-    MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf
-    MsCorePkg/UnitTests/JsonTest/JsonTestApp.inf
-    MsCorePkg/UnitTests/MathLibUnitTest/MathLibUnitTestApp.inf
-    # MsGraphicsPkg/UnitTests/SpinnerTest/SpinnerTest.inf # DOESN'T PRODUCE OUTPUT
-    MsWheaPkg/Test/UnitTests/Library/LibraryClass/CheckHwErrRecHeaderTestApp.inf
-    MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.inf
-    MsWheaPkg/Test/UnitTests/MsWheaReportUnitTestApp/MsWheaReportUnitTestApp.inf
-    UefiTestingPkg/AuditTests/BootAuditTest/UEFI/BootAuditTestApp.inf
-    # UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/DMAIVRSProtectionUnitTestApp.inf # NOT APPLICABLE TO Q35
-    UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
-    # UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
-    # UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
-    # UefiTestingPkg/AuditTests/UefiVarLockAudit/UEFI/UefiVarLockAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
-    UefiTestingPkg/FunctionalSystemTests/ExceptionPersistenceTestApp/ExceptionPersistenceTestApp.inf
-    UefiTestingPkg/FunctionalSystemTests/MemmapAndMatTestApp/MemmapAndMatTestApp.inf
-    UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.inf
-    # UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/App/SmmPagingProtectionsTestApp.inf # NOT APPLICABLE TO Q35
-    XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTestApp.inf
-    XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf {
-      <PcdsPatchableInModule>
-        #Turn off Halt on Assert and Print Assert so that libraries can
-        #be tested in more of a release mode environment
-        gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
-    }
-    FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
-    MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.inf
-    CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf
-    # MdeModulePkg/Application/MpServicesTest/MpServicesTest.inf
-    # MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
-    MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
-    # MdePkg/Test/ShellTest/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf # TEST IS MOVING TO MU_PLUS
-    MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestApp.inf
-    MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibTestApp.inf
-    # ShellPkg/Application/ShellCTestApp/ShellCTestApp.inf # DOESN'T PRODUCE OUTPUT
-    # ShellPkg/Application/ShellSortTestApp/ShellSortTestApp.inf # DOESN'T PRODUCE OUTPUT
-    UnitTestFrameworkPkg/Library/UnitTestBootLibUsbClass/UnitTestBootLibUsbClass.inf
-    UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
-    # UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf # NOT APPLICABLE TO Q35
-    # UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf # NOT APPLICABLE TO Q35
-    MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
-    UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
-    UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
-    UefiTestingPkg/FunctionalSystemTests/ExceptionPersistenceTestApp/ExceptionPersistenceTestApp.inf
-    # UefiTestingPkg/FunctionalSystemTests/VarPolicyUnitTestApp/VarPolicyUnitTestApp.inf
-    CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf {
-      <LibraryClasses>
-        BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
-        OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf # Contains openSSL library used by BaseCryptoLib
-        IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
-      <PcdsPatchableInModule>
-        #Turn off Halt on Assert and Print Assert so that libraries can
-        #be tested in more of a release mode environment
-        gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
-    }
-
-    # OTHER TESTS
-    UnitTestFrameworkPkg/Library/UnitTestBootLibUsbClass/UnitTestBootLibUsbClass.inf
-    UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
-    UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf
-    UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf
-    MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
-    UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
-
-  !endif
+  AdvLoggerPkg/UnitTests/LineParser/LineParserTestApp.inf
+  CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf {
+    <LibraryClasses>
+      BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
+      OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf # Contains openSSL library used by BaseCryptoLib
+      IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+    <PcdsPatchableInModule>
+      #Turn off Halt on Assert and Print Assert so that libraries can
+      #be tested in more of a release mode environment
+      gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
+  }
+  DfciPkg/UnitTests/DeviceIdTest/DeviceIdTestApp.inf
+  # DfciPkg/UnitTests/DfciVarLockAudit/UEFI/DfciVarLockAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+  FmpDevicePkg/Test/UnitTest/Library/FmpDependencyLib/FmpDependencyLibUnitTestApp.inf
+  MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
+  UefiTestingPkg/FunctionalSystemTests/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf
+  MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestApp.inf
+  MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibTestApp.inf
+  MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf
+  # MsCorePkg/UnitTests/JsonTest/JsonTestApp.inf # SOMETIMES RESULTS IN INFINITE LOOP
+  MsCorePkg/UnitTests/MathLibUnitTest/MathLibUnitTestApp.inf
+  # MsGraphicsPkg/UnitTests/SpinnerTest/SpinnerTest.inf # DOESN'T PRODUCE OUTPUT
+  MsWheaPkg/Test/UnitTests/Library/LibraryClass/CheckHwErrRecHeaderTestApp.inf
+  MsWheaPkg/Test/UnitTests/MsWheaEarlyStorageUnitTestApp/MsWheaEarlyUnitTestApp.inf
+  MsWheaPkg/Test/UnitTests/MsWheaReportUnitTestApp/MsWheaReportUnitTestApp.inf
+  MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
+  MmSupervisorPkg/Test/MmSupvRequestUnitTestApp/MmSupvRequestUnitTestApp.inf
+  MdeModulePkg/Application/MpServicesTest/MpServicesTest.inf
+  # MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+  # ShellPkg/Application/ShellCTestApp/ShellCTestApp.inf # DOESN'T PRODUCE OUTPUT
+  # ShellPkg/Application/ShellSortTestApp/ShellSortTestApp.inf # DOESN'T PRODUCE OUTPUT
+  UnitTestFrameworkPkg/Library/UnitTestBootLibUsbClass/UnitTestBootLibUsbClass.inf
+  UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.inf
+  UefiTestingPkg/AuditTests/BootAuditTest/UEFI/BootAuditTestApp.inf
+  # UefiTestingPkg/AuditTests/DMAProtectionAudit/UEFI/DMAIVRSProtectionUnitTestApp.inf # NOT APPLICABLE TO Q35
+  UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditTestApp.inf
+  # UefiTestingPkg/AuditTests/PagingAudit/UEFI/SmmPagingAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+  # UefiTestingPkg/AuditTests/TpmEventLogAudit/TpmEventLogAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+  # UefiTestingPkg/AuditTests/UefiVarLockAudit/UEFI/UefiVarLockAuditTestApp.inf # DOESN'T PRODUCE OUTPUT
+  UefiTestingPkg/FunctionalSystemTests/ExceptionPersistenceTestApp/ExceptionPersistenceTestApp.inf
+  UefiTestingPkg/FunctionalSystemTests/MemmapAndMatTestApp/MemmapAndMatTestApp.inf
+  UefiTestingPkg/FunctionalSystemTests/MorLockTestApp/MorLockTestApp.inf
+  # UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/App/SmmPagingProtectionsTestApp.inf # NOT APPLICABLE TO Q35
+  UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/App/MemoryProtectionTestApp.inf
+  UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf
+  UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf
+  # UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf # TEST RUN VIA APPLICATION
+  XmlSupportPkg/Test/UnitTest/XmlTreeLib/XmlTreeLibUnitTestApp.inf
+  XmlSupportPkg/Test/UnitTest/XmlTreeQueryLib/XmlTreeQueryLibUnitTestApp.inf {
+    <PcdsPatchableInModule>
+      #Turn off Halt on Assert and Print Assert so that libraries can
+      #be tested in more of a release mode environment
+      gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
+  }
+!endif
   #########################################
   # SMM Phase modules
   #########################################
@@ -1360,7 +1346,6 @@
   MmSupervisorPkg/Drivers/StandaloneMmIpl/PiSmmIpl.inf
 !endif
   MmSupervisorPkg/Drivers/MmSupervisorErrorReport/MmSupervisorErrorReport.inf
-  MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
 
   #
   # SMM_CORE

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -510,10 +510,10 @@ INF  MsCorePkg/AcpiRGRT/AcpiRgrt.inf
 !endif
 
 !if $(BUILD_UNIT_TESTS) == TRUE
-INF  UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf
-INF  UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf
-INF  MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
-INF  UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf
+  INF  UefiTestingPkg/FunctionalSystemTests/SmmPagingProtectionsTest/Smm/SmmPagingProtectionsTestSmm.inf
+  INF  UefiTestingPkg/FunctionalSystemTests/MemoryProtectionTest/Smm/MemoryProtectionTestSmm.inf
+  INF  MmSupervisorPkg/Test/MmPagingAuditTest/UEFI/MmPagingAuditApp.inf
+  # INF  UefiTestingPkg/AuditTests/PagingAudit/UEFI/DxePagingAuditDriver.inf # TEST RUN VIA APPLICATION
 !endif
 
 # PRM Configuration Driver

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.ci.yaml
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.ci.yaml
@@ -141,7 +141,8 @@
             "BOCHS",
             "dispi",
             "noclearmem",
-            "unblank"
+            "unblank",
+            "dmaivrs"
         ],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)


### PR DESCRIPTION
Add virtual drive support for linux distros and run unit testing during CI for Linux GCC5 Q35 and SBSA, and Windows Q35.