### PR TITLE
Fix "Temp" references in repo

### DIFF
--- a/Platforms/QemuQ35Pkg/Docs/QemuQ35_ReadMe.md
+++ b/Platforms/QemuQ35Pkg/Docs/QemuQ35_ReadMe.md
@@ -2,7 +2,7 @@
 
 **QemuQ35Pkg...**
 
-- Is a derivative of Temp.
+- Is a derivative of OvmfPkg.
 - Will not support Legacy BIOS or CSM.
 - WIll not support S3 sleep functionality.
 - Has a 32-bit PEI phase and a 64-bit DXE phase.

--- a/Platforms/QemuQ35Pkg/Library/MsPlatformDevicesLibQemuQ35/MsPlatformDevicesLib.c
+++ b/Platforms/QemuQ35Pkg/Library/MsPlatformDevicesLibQemuQ35/MsPlatformDevicesLib.c
@@ -1214,7 +1214,7 @@ GetPlatformConnectList (
   // Since this is the best place to do this, let's connect the VirtioRng
   // This is in BeforeConsole in Qemu, and this is function that's called in Q35 AfterConsole
   // So there might be some slight timing differences between when Rng comes up on Ovmf vs Q35
-  // From Platforms/Temp/Library/PlatformBootManagerLib/BdsPlatform.c:433 (as of 202005 or a47822d46)
+  // From edk2 OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c:433 (as of 202005 or a47822d46)
   // Install both VIRTIO_DEVICE_PROTOCOL and (dependent) EFI_RNG_PROTOCOL
   // instances on Virtio PCI RNG devices.
   //

--- a/Platforms/QemuQ35Pkg/Library/PlatformDebugLibIoPort/ReadMe.md
+++ b/Platforms/QemuQ35Pkg/Library/PlatformDebugLibIoPort/ReadMe.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This library is derived from DebugLib in Temp.
+This library is derived from DebugLib in OvmfPkg.
 It corrected several typos from the original library and added support for DEBUG_BUFFER function.
 
 ## Copyright

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.ci.yaml
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.ci.yaml
@@ -28,7 +28,6 @@
         "AcceptableDependencies": [
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
-            "Temp/Temp.dec",
             "NetworkPkg/NetworkPkg.dec",
             "SecurityPkg/SecurityPkg.dec",
             "UefiCpuPkg/UefiCpuPkg.dec",

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dec
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dec
@@ -1,7 +1,7 @@
 ## @file
 #  ProjectMu QemuQ35Pkg
 #
-#  Package is a derivitive of the open source Temp
+#  Package is a derivitive of the open source OVMF package.
 #
 #  Copyright (c) Microsoft Corporation
 #

--- a/Platforms/QemuQ35Pkg/QemuVideoDxe/ReadMe.md
+++ b/Platforms/QemuQ35Pkg/QemuVideoDxe/ReadMe.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This driver is derived from sample GOP driver QemuVideoDxe in Temp.
+This driver is derived from sample GOP driver QemuVideoDxe in OvmfPkg.
 It replaces the standard GOP interfaces GUID with MsGopOverrideProtocolGuid from Project Mu to allow further
 graphics control through Mu interfaces. It also removes support for BOCHS due to out of project scope.
 


### PR DESCRIPTION
## Description

It appears "temp" was used in search and replace during an earlier refactor
and accidentally checked in. Occurrences are fixed in this change.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>