### PR TITLE
Add FrontPageButtons to QemuQ35Pkg

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -969,8 +969,8 @@
   #########################################
   # DXE Phase modules
   #########################################
-  # Spoofs button press to automatically boot to FrontPage.
-  OemPkg/FrontpageButtonsVolumeUp/FrontpageButtonsVolumeUp.inf
+  # Reads smbios type 3 to determine volume button state.
+  QemuPkg/FrontPageButtons/FrontPageButtons.inf
 
   # Application that presents and manages FrontPage.
   OemPkg/FrontPage/FrontPage.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -556,6 +556,7 @@ FILE FREEFORM = PCD(gZeroTouchPkgTokenSpaceGuid.PcdZeroTouchCertificateFile) {
   INF MsGraphicsPkg/RenderingEngineDxe/RenderingEngineDxe.inf
   INF MsGraphicsPkg/DisplayEngineDxe/DisplayEngineDxe.inf
   INF OemPkg/BootMenu/BootMenu.inf
+  INF QemuPkg/FrontPageButtons/FrontPageButtons.inf
   INF OemPkg/FrontPage/FrontPage.inf
   INF PcBdsPkg/MsBootPolicy/MsBootPolicy.inf
   INF MdeModulePkg/Universal/BootManagerPolicyDxe/BootManagerPolicyDxe.inf

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.c
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.c
@@ -112,12 +112,18 @@ PreBootClearVolumeButtonState (
 /**
   Get Bios String  - Return address of Bios String
 
+@param[in]  StringPtr  - Pointer to the SMBIOS Multi-string
+@param[in]  Index      - Index of the string requested (1 based)
+
+@retval                - Pointer to the SMBIOS string[index] at index requested.
+                         If index causes traversal of the end of string, the pointer
+                         to the NULL byte is returned.
 **/
 STATIC
 CHAR8 *
 GetBiosString (
-  CHAR8  *StringPtr,
-  INTN   Index
+  IN  CHAR8  *StringPtr,
+  IN  INTN   Index
   )
 {
   CHAR8  *TempPtr;

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.c
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.c
@@ -1,0 +1,230 @@
+/** @file FrontpageButtons.c
+
+ This module installs the MsButtonServicesProtocol and reports the requested state of Vol+ and
+ Vol- as indicated by the smbios table type3 record version string.
+
+ If the Type3.version string is:
+     "Vol+"  -- Return Vol+ pressed.
+     "Vol-"  -- Return Vol- pressed.
+     any other string, or no string, return neither pressed
+
+  Use only for Qemu platforms which can change smbios every time it boots.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Uefi.h>
+
+#include <Protocol/ButtonServices.h>
+#include <Protocol/Smbios.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+typedef enum {
+  NoButtons     = 0,
+  VolUpButton   = 1,
+  VolDownButton = 2
+} BUTTON_STATE;
+
+#define SMBIOS_VOLUP    "Vol+"
+#define SMBIOS_VOLDOWN  "Vol-"
+
+BUTTON_STATE  ButtonState = NoButtons;
+
+/*
+Say volume button is pressed because we wan to go to frontpage.
+*/
+EFI_STATUS
+EFIAPI
+PreBootVolumeUpButtonThenPowerButtonCheck (
+  IN  MS_BUTTON_SERVICES_PROTOCOL  *This,
+  OUT BOOLEAN                      *PreBootVolumeUpButtonThenPowerButton // TRUE if button combo set else FALSE
+  )
+{
+  DEBUG ((DEBUG_ERROR, "%a \n", __FUNCTION__));
+  *PreBootVolumeUpButtonThenPowerButton = (ButtonState == VolUpButton);
+  return EFI_SUCCESS;
+}
+
+/*
+Say no because we don't want alt boot.
+*/
+EFI_STATUS
+EFIAPI
+PreBootVolumeDownButtonThenPowerButtonCheck (
+  IN  MS_BUTTON_SERVICES_PROTOCOL  *This,
+  OUT BOOLEAN                      *PreBootVolumeDownButtonThenPowerButton // TRUE if button combo set else FALSE
+  )
+{
+  DEBUG ((DEBUG_ERROR, "%a \n", __FUNCTION__));
+  *PreBootVolumeDownButtonThenPowerButton = (ButtonState == VolDownButton);
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+PreBootClearVolumeButtonState (
+  MS_BUTTON_SERVICES_PROTOCOL  *This
+  )
+{
+  DEBUG ((DEBUG_ERROR, "%a \n", __FUNCTION__));
+  ButtonState = NoButtons;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get Bios String  - Return address of Bios String
+
+**/
+STATIC
+CHAR8 *
+GetBiosString (
+  CHAR8  *StringPtr,
+  INTN   Index
+  )
+{
+  CHAR8  *TempPtr;
+
+  if (Index == 0) {
+    return NULL;
+  }
+
+  TempPtr = StringPtr;
+  while ((*TempPtr != '\0') && (--Index > 0)) {
+    while (*TempPtr++ != '\0') {
+    }
+  }
+
+  return TempPtr;
+}
+
+/**
+  GetButtonState   - Get the sate of the Vol+/Vol- button
+
+@return EFI_SUCCESS - String buffer returned to caller
+@return EFI_ERROR   - Error the string
+
+**/
+EFI_STATUS
+GetButtonState (
+  VOID
+  )
+{
+  CHAR8                *BiosString;
+  EFI_SMBIOS_PROTOCOL  *Smbios;
+  EFI_SMBIOS_TYPE      SmbiosType;
+  EFI_SMBIOS_HANDLE    SmbiosHandle;
+  SMBIOS_STRUCTURE     *SmbiosRecord;
+  SMBIOS_TABLE_TYPE3   *SmbiosType3;
+  EFI_STATUS           Status;
+  CHAR8                *StringPtr;
+  UINTN                StrLen;
+
+  Status = EFI_SUCCESS;
+
+  DEBUG ((DEBUG_ERROR, "%a: Entry\n", __FUNCTION__));
+
+  Status = gBS->LocateProtocol (&gEfiSmbiosProtocolGuid, NULL, (VOID *)&Smbios);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Unable to locate SmBiosProtocol.  Code=%r\n", __FUNCTION__, Status));
+    goto Exit;
+  }
+
+  SmbiosType   = SMBIOS_TYPE_SYSTEM_ENCLOSURE;
+  SmbiosHandle = 0xFFFe;
+
+  // -smbios type=3,version=V+
+
+  Status = Smbios->GetNext (Smbios, &SmbiosHandle, &SmbiosType, &SmbiosRecord, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Unable to get type 3 SMBIOS record.  Code=%r\n", __FUNCTION__, Status));
+    goto Exit;
+  }
+
+  SmbiosType3 = (SMBIOS_TABLE_TYPE3 *)SmbiosRecord;
+  StringPtr   = (CHAR8 *)SmbiosType3 + SmbiosType3->Hdr.Length;
+
+  DEBUG ((DEBUG_INFO, "Type 3 = %p, Size=0x%x, String = %p\n", SmbiosType3, SmbiosType3->Hdr.Length, StringPtr));
+  DUMP_HEX (DEBUG_INFO, 0, SmbiosType3, ((UINTN)StringPtr | 0xFFF) - (UINTN)SmbiosType3, "");
+
+  BiosString = GetBiosString (StringPtr, SmbiosType3->Version);
+
+  if (BiosString != NULL) {
+    StrLen = AsciiStrLen (BiosString);
+
+    if ((StrLen == AsciiStrLen (SMBIOS_VOLUP))  &&
+        (0 == AsciiStrCmp (BiosString, SMBIOS_VOLUP)))
+    {
+      ButtonState = VolUpButton;
+      DEBUG ((DEBUG_INFO, "%a: Vol+ Button Detected\n", __FUNCTION__));
+    }
+
+    if ((StrLen == AsciiStrLen (SMBIOS_VOLDOWN)) &&
+        (0 == AsciiStrCmp (BiosString, SMBIOS_VOLDOWN)))
+    {
+      ButtonState = VolDownButton;
+      DEBUG ((DEBUG_INFO, "%a: Vol- Button Detected\n", __FUNCTION__));
+    }
+  }
+
+  if (ButtonState == NoButtons) {
+    DEBUG ((DEBUG_INFO, "%a: Neither Vol+ nor Vol- detected\n", __FUNCTION__));
+  }
+
+Exit:
+  return Status;
+}
+
+/**
+ Init routine to install protocol and init anything related to buttons
+
+ **/
+EFI_STATUS
+EFIAPI
+ButtonsInit (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  MS_BUTTON_SERVICES_PROTOCOL  *Protocol = NULL;
+  EFI_STATUS                   Status    = EFI_SUCCESS;
+
+  DEBUG ((DEBUG_ERROR, "%a \n", __FUNCTION__));
+
+  Status = GetButtonState ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Protocol = AllocateZeroPool (sizeof (MS_BUTTON_SERVICES_PROTOCOL));
+  if (Protocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "Failed to allocate memory for button service protocol.\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Protocol->PreBootVolumeDownButtonThenPowerButtonCheck = PreBootVolumeDownButtonThenPowerButtonCheck;
+  Protocol->PreBootVolumeUpButtonThenPowerButtonCheck   = PreBootVolumeUpButtonThenPowerButtonCheck;
+  Protocol->PreBootClearVolumeButtonState               = PreBootClearVolumeButtonState;
+
+  // Install the protocol
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &ImageHandle,
+                  &gMsButtonServicesProtocolGuid,
+                  Protocol,
+                  NULL
+                  );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Button Services Protocol Publisher: install protocol error, Status = %r.\n", Status));
+    FreePool (Protocol);
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "Button Services Protocol Installed!\n"));
+  return Status;
+}

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.c
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.c
@@ -57,7 +57,7 @@ PreBootVolumeUpButtonThenPowerButtonCheck (
 {
   FRONT_PAGE_BUTTON_SERVICES_PROTOCOL  *Bsp;
 
-  DEBUG ((DEBUG_ERROR, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
 
   Bsp                                   = MS_BSP_FROM_BSP (This);
   *PreBootVolumeUpButtonThenPowerButton = (Bsp->ButtonState == VolUpButton);
@@ -79,9 +79,9 @@ PreBootVolumeDownButtonThenPowerButtonCheck (
   OUT BOOLEAN                      *PreBootVolumeDownButtonThenPowerButton // TRUE if button combo set else FALSE
   )
 {
-  DEBUG ((DEBUG_ERROR, "%a \n", __FUNCTION__));
   FRONT_PAGE_BUTTON_SERVICES_PROTOCOL  *Bsp;
 
+  DEBUG ((DEBUG_VERBOSE, "%a \n", __FUNCTION__));
   Bsp                                     = MS_BSP_FROM_BSP (This);
   *PreBootVolumeDownButtonThenPowerButton = (Bsp->ButtonState == VolDownButton);
   return EFI_SUCCESS;
@@ -100,9 +100,9 @@ PreBootClearVolumeButtonState (
   IN  MS_BUTTON_SERVICES_PROTOCOL  *This
   )
 {
-  DEBUG ((DEBUG_ERROR, "%a \n", __FUNCTION__));
   FRONT_PAGE_BUTTON_SERVICES_PROTOCOL  *Bsp;
 
+  DEBUG ((DEBUG_VERBOSE, "%a \n", __FUNCTION__));
   Bsp              = MS_BSP_FROM_BSP (This);
   Bsp->ButtonState = NoButtons;
 

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.c
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.c
@@ -30,8 +30,8 @@ typedef enum {
   VolDownButton = 2
 } BUTTON_STATE;
 
-#define SMBIOS_VOLUP    "Vol+"
-#define SMBIOS_VOLDOWN  "Vol-"
+#define SMBIOS_VOLUME_UP    "Vol+"
+#define SMBIOS_VOLUME_DOWN  "Vol-"
 
 BUTTON_STATE  gButtonState = NoButtons;
 
@@ -175,15 +175,15 @@ GetButtonState (
   if (BiosString != NULL) {
     StrLen = AsciiStrLen (BiosString);
 
-    if ((StrLen == AsciiStrLen (SMBIOS_VOLUP))  &&
-        (0 == AsciiStrCmp (BiosString, SMBIOS_VOLUP)))
+    if ((StrLen == AsciiStrLen (SMBIOS_VOLUME_UP))  &&
+        (0 == AsciiStrCmp (BiosString, SMBIOS_VOLUME_UP)))
     {
       gButtonState = VolUpButton;
       DEBUG ((DEBUG_INFO, "%a: Vol+ Button Detected\n", __FUNCTION__));
     }
 
-    if ((StrLen == AsciiStrLen (SMBIOS_VOLDOWN)) &&
-        (0 == AsciiStrCmp (BiosString, SMBIOS_VOLDOWN)))
+    if ((StrLen == AsciiStrLen (SMBIOS_VOLUME_DOWN)) &&
+        (0 == AsciiStrCmp (BiosString, SMBIOS_VOLUME_DOWN)))
     {
       gButtonState = VolDownButton;
       DEBUG ((DEBUG_INFO, "%a: Vol- Button Detected\n", __FUNCTION__));

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.c
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.c
@@ -1,4 +1,4 @@
-/** @file FrontpageButtons.c
+/** @file FrontPageButtons.c
 
  This module installs the MsButtonServicesProtocol and reports the requested state of Vol+ and
  Vol- as indicated by the smbios table type3 record version string.
@@ -36,7 +36,7 @@ typedef enum {
 BUTTON_STATE  gButtonState = NoButtons;
 
 /*
-Say volume up button is pressed because we want to go to frontpage.
+Say volume up button is pressed because we want to go to Front Page.
 
 @param[in]     - Button Services protocol pointer
 @param[out]    - Pointer to a boolean value to receive the button state

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.c
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.c
@@ -57,7 +57,7 @@ PreBootVolumeUpButtonThenPowerButtonCheck (
 {
   FRONT_PAGE_BUTTON_SERVICES_PROTOCOL  *Bsp;
 
-  DEBUG ((DEBUG_INFO, "%a \n", __FUNCTION__));
+  DEBUG ((DEBUG_VERBOSE, "%a \n", __FUNCTION__));
 
   Bsp                                   = MS_BSP_FROM_BSP (This);
   *PreBootVolumeUpButtonThenPowerButton = (Bsp->ButtonState == VolUpButton);

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.inf
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.inf
@@ -1,0 +1,52 @@
+## @file FrontpageButtons.inf
+#
+# This module installs the MsButtonServicesProtocol and reports the requested state of Vol+ and
+# Vol- as indicated by the smbios table type3 record version string.
+#
+# If the Type3.version string is:
+#     "Vol+"  -- Return Vol+ pressed.
+#     "Vol-"  -- Return Vol- pressed.
+#     any other string, or no string, return neither pressed
+#
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FrontpageButtons
+  FILE_GUID                      = d91fb421-e24f-4839-9a44-dc77189e87d2
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = ButtonsInit
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC AARCH64
+#
+
+[Sources]
+  FrontPageButtons.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  OemPkg/OemPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+
+[Guids]
+
+[Protocols]
+  gMsButtonServicesProtocolGuid          #PRODUCES
+  gEfiSmbiosProtocolGuid                 #CONSUMES
+
+[Pcd]
+
+[Depex]
+  gEfiSmbiosProtocolGuid

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.inf
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.inf
@@ -13,7 +13,7 @@
 ##
 
 [Defines]
-  INF_VERSION                    = 0x00010005
+  INF_VERSION                    = 1.27
   BASE_NAME                      = FrontpageButtons
   FILE_GUID                      = d91fb421-e24f-4839-9a44-dc77189e87d2
   MODULE_TYPE                    = DXE_DRIVER
@@ -40,13 +40,9 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
 
-[Guids]
-
 [Protocols]
   gMsButtonServicesProtocolGuid          #PRODUCES
   gEfiSmbiosProtocolGuid                 #CONSUMES
-
-[Pcd]
 
 [Depex]
   gEfiSmbiosProtocolGuid

--- a/QemuPkg/FrontPageButtons/FrontPageButtons.inf
+++ b/QemuPkg/FrontPageButtons/FrontPageButtons.inf
@@ -1,4 +1,4 @@
-## @file FrontpageButtons.inf
+## @file FrontPageButtons.inf
 #
 # This module installs the MsButtonServicesProtocol and reports the requested state of Vol+ and
 # Vol- as indicated by the smbios table type3 record version string.
@@ -14,7 +14,7 @@
 
 [Defines]
   INF_VERSION                    = 1.27
-  BASE_NAME                      = FrontpageButtons
+  BASE_NAME                      = FrontPageButtons
   FILE_GUID                      = d91fb421-e24f-4839-9a44-dc77189e87d2
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
@@ -23,7 +23,7 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC AARCH64
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
 #
 
 [Sources]

--- a/QemuPkg/QemuPkg.ci.yaml
+++ b/QemuPkg/QemuPkg.ci.yaml
@@ -96,7 +96,8 @@
             "pmregmisc",
             "pointee",
             "ramfb",
-            "rebecca"
+            "rebecca",
+            "tsegmb"
           ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)

--- a/QemuPkg/QemuPkg.dsc
+++ b/QemuPkg/QemuPkg.dsc
@@ -145,6 +145,7 @@
   QemuPkg/Library/VirtioLib/VirtioLib.inf
   QemuPkg/Library/QemuFwCfgLib/QemuFwCfgLibNull.inf
   QemuPkg/Library/XenPlatformLib/XenPlatformLib.inf
+  QemuPkg/FrontPageButtons/FrontPageButtons.inf
   QemuPkg/PciHotPlugInitDxe/PciHotPlugInit.inf
   QemuPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
   QemuPkg/Virtio10Dxe/Virtio10.inf


### PR DESCRIPTION
Add the smbios FrontPageButton driver

## Description

Add the driver that maps the Type3.version Smbios data to the respective Vol+ or Vol- action.

One PR for #472 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?

- [ ] Impacts security?
 
- [ ] Breaking change?
 
- [ ] Includes tests?

- [ ] Includes documentation?


## How This Was Tested

Tested on a Q35 system

## Integration Instructions

N/A
