### PR TITLE
Update the default Q35 cores to 4 and run pipeline at 2

### DIFF
--- a/.azurepipelines/Platform-Build-Job.yml
+++ b/.azurepipelines/Platform-Build-Job.yml
@@ -43,7 +43,7 @@ jobs:
           Build.Flags: ""
           Build.Target: "DEBUG"
           Run: true
-          Run.Flags: $(run_flags)
+          Run.Flags: $(run_flags) BLD_*_QEMU_CORE_NUM=2
           Build.ArtifactsBinary: |
             **/QEMUQ35_*.fd
 
@@ -54,7 +54,7 @@ jobs:
           Build.Flags: ""
           Build.Target: "RELEASE"
           Run: true
-          Run.Flags: $(run_flags)
+          Run.Flags: $(run_flags) BLD_*_QEMU_CORE_NUM=2
           Build.ArtifactsBinary: |
             **/QEMUQ35_*.fd
 

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -271,7 +271,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         # Default turn on build reporting.
         self.env.SetValue("BUILDREPORTING", "TRUE", "Enabling build report")
         self.env.SetValue("BUILDREPORT_TYPES", "PCD DEPEX FLASH BUILD_FLAGS LIBRARY FIXED_ADDRESS HASH", "Setting build report types")
-        self.env.SetValue("BLD_*_QEMU_CORE_NUM", "2", "Default")
+        self.env.SetValue("BLD_*_QEMU_CORE_NUM", "4", "Default")
         self.env.SetValue("BLD_*_MEMORY_PROTECTION", "TRUE", "Default")
         # Include the MFCI test cert by default, override on the commandline with "BLD_*_SHIP_MODE=TRUE" if you want the retail MFCI cert
         self.env.SetValue("BLD_*_SHIP_MODE", "FALSE", "Default")
@@ -502,13 +502,13 @@ class LinuxVirtualDriveManager(object):
         if ret != 0:
             logging.error("Failed to create IMG")
             return ret
-        
+
         # Format the image as FAT32
         ret = RunCmd("mkfs.vfat", f"{self.drive_path}")
         if ret != 0:
             logging.error("Failed to format IMG")
             return ret
-        
+
         # Create an mtools config file to virtually map the image to a drive letter
         RunCmd("echo", "mtools_skip_check=1 > ~/.mtoolsrc")
         RunCmd("echo", f"drive {self.drive_letter}: >> ~/.mtoolsrc")


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Increase the max number of cores up to 4 for a more standard and useful VM core number. 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local simple boot test.

## Integration Instructions

N/A
