### PR TITLE
Enable features used by the Windows hypervisor

### DIFF
--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -295,7 +295,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args += " ARCH=" + self.env.GetValue("TARGET_ARCH").lower()
         args += " DEBUG=" + str(1 if self.env.GetValue("TARGET").lower() == 'debug' else 0)
         args += " SPM_MM=1 EL3_EXCEPTION_HANDLING=1"
-        args += " ENABLE_FEAT_HCX=1 ENABLE_FEAT_FGT=1" # Features used by hypervisor
+        args += " ENABLE_FEAT_HCX=1" # Features used by hypervisor
         # args += " FEATURE_DETECTION=1" # Enforces support for features enabled.
         args += " BL32=" + os.path.join(op_fv, "BL32_AP_MM.fd")
         args += " all fip"

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -88,7 +88,7 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
 
     def GetRequiredSubmodules(self):
         """Return iterable containing RequiredSubmodule objects.
-        
+
         !!! note
             If no RequiredSubmodules return an empty iterable
         """
@@ -295,6 +295,8 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args += " ARCH=" + self.env.GetValue("TARGET_ARCH").lower()
         args += " DEBUG=" + str(1 if self.env.GetValue("TARGET").lower() == 'debug' else 0)
         args += " SPM_MM=1 EL3_EXCEPTION_HANDLING=1"
+        args += " ENABLE_FEAT_HCX=1 ENABLE_FEAT_FGT=1" # Features used by hypervisor
+        # args += " FEATURE_DETECTION=1" # Enforces support for features enabled.
         args += " BL32=" + os.path.join(op_fv, "BL32_AP_MM.fd")
         args += " all fip"
         args += " -j $(nproc)"
@@ -538,13 +540,13 @@ class LinuxVirtualDriveManager(object):
         if ret != 0:
             logging.error("Failed to create IMG")
             return ret
-        
+
         # Format the image as FAT32
         ret = RunCmd("mkfs.vfat", f"{self.drive_path}")
         if ret != 0:
             logging.error("Failed to format IMG")
             return ret
-        
+
         # Create an mtools config file to virtually map the image to a drive letter
         RunCmd("echo", "mtools_skip_check=1 > ~/.mtoolsrc")
         RunCmd("echo", f"drive {self.drive_letter}: >> ~/.mtoolsrc")


### PR DESCRIPTION
## Description

Enables access to the HCRX register and functionality which is used by the Windows hypervisor. For information on this flag and feature see, https://trustedfirmware-a.readthedocs.io/en/latest/getting_started/build-options.html.

Launching the Windows hypervisor in SBSA requires fixes coming in QEMU 8.0 and Windows fixes whose release build is not yet determined.


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Manually tested locally.

## Integration Instructions

N/A
