### PR TITLE
Update Build-UefiExt.yaml to publish on manual action.

### DIFF
--- a/.github/workflows/Build-UefiExt.yaml
+++ b/.github/workflows/Build-UefiExt.yaml
@@ -38,7 +38,7 @@ jobs:
         run: msbuild UefiDbgExt\uefiext.vcxproj -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }}
       
       - name: Publish Binary
-        if: ${{ matrix.configuration == 'Release' && github.event_name == 'push' }}
+        if: ${{ matrix.configuration == 'Release' && github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v3
         with:
           name: UefiDbgExt-${{ matrix.platform }}-${{ matrix.configuration }}


### PR DESCRIPTION
## Description

Updates Build-UefiExt.yaml to upload the dll artifact on manual runs to allow manual refresh of binary. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
