### PR TITLE
Publish "No SMM" Q35 binaries on release

### DIFF
--- a/.azurepipelines/templates/Job-Publish.yml
+++ b/.azurepipelines/templates/Job-Publish.yml
@@ -46,6 +46,14 @@ jobs:
             vs_artifact_name: 'Binaries QemuQ35Pkg VS2022 RELEASE'
             vs_folder_name: VisualStudio-x64
 
+          QEMU Q35 No SMM Release:
+            gcc_artifact_name: 'Binaries QemuQ35Pkg GCC5 RELEASE NO_SMM'
+            gcc_folder_name: GCC-NoSmm-x64
+            nuget_package_config_file: >-
+              Platforms/QemuQ35Pkg/NugetPublishing/ReleaseNoSmmConfig.yaml
+            vs_artifact_name: 'Binaries QemuQ35Pkg VS2022 RELEASE NO_SMM'
+            vs_folder_name: VisualStudio-NoSmm-x64
+
         ${{ if eq(parameters.publish_sbsa_binaries, true) }}:
           QEMU SBSA Debug:
             gcc_artifact_name: 'Binaries QemuSbsaPkg GCC5 DEBUG'

--- a/Platforms/QemuQ35Pkg/NugetPublishing/ReleaseNoSmmConfig.yaml
+++ b/Platforms/QemuQ35Pkg/NugetPublishing/ReleaseNoSmmConfig.yaml
@@ -1,0 +1,9 @@
+author_string: Microsoft Core UEFI
+copyright_string: Copyright (c) Microsoft Corporation.
+description_string: QEMU Q35 No SMM RELEASE Platform Firmware
+name: Mu.QemuQ35.NoSmm.FW.RELEASE
+project_url: https://microsoft.github.io/mu/
+repository_type: git
+repository_url: https://github.com/microsoft/mu_tiano_platforms
+server_url: https://nuget.pkg.github.com/microsoft/index.json
+tags_string: ''


### PR DESCRIPTION
## Description

Resolves #513

Updates the release process to also include the QemuQ35Pkg binaries built without SMM.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

PR gates and test release on fork.

## Integration Instructions

N/A - Affects release publication