### PR TITLE
Generate the Paging Audit When Running DxePagingAuditTestApp on Q35 and SBSA

### DIFF
--- a/.azurepipelines/Platform-Build-Job.yml
+++ b/.azurepipelines/Platform-Build-Job.yml
@@ -49,6 +49,7 @@ jobs:
           Run.Flags: $(run_flags) BLD_*_QEMU_CORE_NUM=2
           Build.ArtifactsBinary: |
             **/QEMUQ35_*.fd
+          Build.ArtifactsOther: "**/unit_test_results/*"
 
         QemuQ35_RELEASE:
           Build.Package: QemuQ35Pkg
@@ -61,6 +62,7 @@ jobs:
           Run.Flags: $(run_flags) BLD_*_QEMU_CORE_NUM=2
           Build.ArtifactsBinary: |
             **/QEMUQ35_*.fd
+          Build.ArtifactsOther: "**/unit_test_results/*"
 
         QemuQ35_NO_SMM_RELEASE:
           Build.Package: QemuQ35Pkg
@@ -73,6 +75,7 @@ jobs:
           Run.Flags: $(run_flags_no_tests) BLD_*_QEMU_CORE_NUM=2 BLD_*_SMM_ENABLED=FALSE
           Build.ArtifactsBinary: |
             **/QEMUQ35_*.fd
+          Build.ArtifactsOther: ""
 
         ${{ if eq(parameters.tool_chain_tag, 'GCC5') }}:
           QemuSbsa_DEBUG:
@@ -87,6 +90,7 @@ jobs:
             Build.ArtifactsBinary: |
               **/QEMU_EFI.fd
               **/SECURE_FLASH0.fd
+            Build.ArtifactsOther: "**/unit_test_results/*"
 
           QemuSbsa_RELEASE:
             Build.Package: QemuSbsaPkg
@@ -100,6 +104,7 @@ jobs:
             Build.ArtifactsBinary: |
               **/QEMU_EFI.fd
               **/SECURE_FLASH0.fd
+            Build.ArtifactsOther: "**/unit_test_results/*"
 
     workspace:
       clean: all
@@ -130,3 +135,4 @@ jobs:
         install_tools: ${{ eq(parameters.container_image, '') }}
         artifacts_identifier: '$(Build.Package) ${{ parameters.tool_chain_tag }} $(Build.Target) $(Build.ExtraTag)'
         artifacts_binary: $(Build.ArtifactsBinary)
+        artifacts_other: $(Build.ArtifactsOther)

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -360,8 +360,11 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             test_list = []
             for pattern in test_regex.split(","):
                 test_list.extend(Path(output_base, "X64").glob(pattern))
-            
-            self.Helper.add_tests(virtual_drive, test_list, auto_run = run_tests, auto_shutdown = shutdown_after_run)
+            run_paging_audit = False
+            if any("DxePagingAuditTestApp.efi" in os.path.basename(test) for test in test_list):
+                run_paging_audit = True
+                
+            self.Helper.add_tests(virtual_drive, test_list, auto_run = run_tests, auto_shutdown = shutdown_after_run, paging_audit = run_paging_audit)
         # Otherwise add an empty startup script
         else:
             virtual_drive.add_startup_script([], auto_shutdown=shutdown_after_run)
@@ -398,6 +401,8 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         # Filter out tests that are exempt
         tests = list(filter(lambda file: file.name not in FET or not (now - FET.get(file.name)).total_seconds() < FEOL, test_list))
         
+        if (run_paging_audit):
+            self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"))
         # Helper located at QemuPkg/Plugins/VirtualDriveManager
         return self.Helper.report_results(virtual_drive, tests, Path(drive_path).parent / "unit_test_results")
 

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -333,7 +333,8 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         empty_drive = (self.env.GetValue("EMPTY_DRIVE", "FALSE").upper() == "TRUE")
         test_regex = self.env.GetValue("TEST_REGEX", "")
         drive_path = self.env.GetValue("VIRTUAL_DRIVE_PATH")
-        
+        run_paging_audit = False
+ 
         # General debugging information for users
         if run_tests:
             if test_regex == "":
@@ -360,7 +361,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             test_list = []
             for pattern in test_regex.split(","):
                 test_list.extend(Path(output_base, "X64").glob(pattern))
-            run_paging_audit = False
+
             if any("DxePagingAuditTestApp.efi" in os.path.basename(test) for test in test_list):
                 run_paging_audit = True
                 
@@ -401,8 +402,9 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         # Filter out tests that are exempt
         tests = list(filter(lambda file: file.name not in FET or not (now - FET.get(file.name)).total_seconds() < FEOL, test_list))
         
-        if (run_paging_audit):
+        if run_paging_audit:
             self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"))
+            
         # Helper located at QemuPkg/Plugins/VirtualDriveManager
         return self.Helper.report_results(virtual_drive, tests, Path(drive_path).parent / "unit_test_results")
 

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -402,7 +402,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"))
 
         # Filter out tests that are exempt
-        tests = list(filter(lambda file: file.name not in FET or not (now - FET.get(file.name)).total_seconds() < FEOL, test_list))            
+        tests = list(filter(lambda file: file.name not in FET or not (now - FET.get(file.name)).total_seconds() < FEOL, test_list))
         tests_exempt = list(filter(lambda file: file.name in FET and (now - FET.get(file.name)).total_seconds() < FEOL, test_list))       
         if len(tests_exempt) > 0:
             self.Helper.report_results(virtual_drive, tests_exempt, Path(drive_path).parent / "unit_test_results")

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -367,6 +367,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         empty_drive = (self.env.GetValue("EMPTY_DRIVE", "FALSE").upper() == "TRUE")
         test_regex = self.env.GetValue("TEST_REGEX", "")
         drive_path = self.env.GetValue("VIRTUAL_DRIVE_PATH")
+        run_paging_audit = False
 
         # General debugging information for users
         if run_tests:
@@ -394,7 +395,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
             test_list = []
             for pattern in test_regex.split(","):
                 test_list.extend(Path(output_base, "AARCH64").glob(pattern))
-            run_paging_audit = False
+
             if any("DxePagingAuditTestApp.efi" in os.path.basename(test) for test in test_list):
                 run_paging_audit = True
             
@@ -435,8 +436,8 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         # Filter out tests that are exempt
         tests = list(filter(lambda file: file.name not in FET or not (now - FET.get(file.name)).total_seconds() < FEOL, test_list))
         
-        if paging_audit:
-                tests.append("DxePagingAuditTestApp.efi -d")
+        if run_paging_audit:
+            self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"))
 
         # Helper located at QemuPkg/Plugins/VirtualDriveManager
         return self.Helper.report_results(virtual_drive, tests, Path(drive_path).parent / "unit_test_results")

--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -458,5 +458,5 @@ class VirtualDriveManager(IUefiHelperPlugin):
         result = RunCmd(cmd, args)
         if result != 0:
             e = f"[{cmd} {args}] Result: {result}"
-            logger.error("Drive could not be created.")
+            logger.error("Paging audit could not be created.")
             logger.error(e)

--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -447,7 +447,7 @@ class VirtualDriveManager(IUefiHelperPlugin):
                                    "GuardPage.dat", "MemoryInfoDatabase.dat"]
         paging_audit_generator_path = os.path.join("Common", "MU", "UefiTestingPkg", "AuditTests",
                                                    "PagingAudit", "Windows", "PagingReportGenerator.py")
-
+        report_output_dir.mkdir(exist_ok=True)
         for file in paging_audit_data_files:
             drive.get_file(file, os.path.join(report_output_dir, file))
         output_audit = os.path.join(report_output_dir, "pagingaudit.html")

--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -191,7 +191,8 @@ class LinuxVirtualDrive(VirtualDrive):
             (RuntimeError): Failed to get the filepath
         """
         cmd = "mcopy"
-        args = f"-n -i {self.drive_path} {virtual_path} {local_path}"
+        full_path = os.path.join(self.drive_letter + ":", virtual_path)
+        args = f"-n -i {self.drive_path} {full_path} {local_path}"
         result = RunCmd(cmd, args)
         if result != 0:
             e = f"[{cmd} {args}] Result: {result}"
@@ -211,7 +212,6 @@ class LinuxVirtualDrive(VirtualDrive):
         """
         if local_path is None:
             local_path = tempfile.mktemp()
-        virtual_path = str(Path(self.drive_letter + ":", virtual_path))
         self.get_file(virtual_path, local_path)
 
         with open(local_path, "rb") as f:
@@ -331,6 +331,7 @@ class VirtualDriveManager(IUefiHelperPlugin):
         obj.Register("get_virtual_drive", VirtualDriveManager.get_virtual_drive, fp)
         obj.Register("add_tests", VirtualDriveManager.add_tests, fp)
         obj.Register("report_results", VirtualDriveManager.report_results, fp)
+        obj.Register("generate_paging_audit", VirtualDriveManager.generate_paging_audit, fp)
         return 0
     
     @staticmethod
@@ -340,7 +341,7 @@ class VirtualDriveManager(IUefiHelperPlugin):
         return LinuxVirtualDrive(path)
     
     @staticmethod
-    def add_tests(drive: VirtualDrive, test_list: list[str], auto_run = True, auto_shutdown = True):
+    def add_tests(drive: VirtualDrive, test_list: list[str], auto_run = True, auto_shutdown = True, paging_audit = False):
         """Adds tests to the virtual drive and optionally adds them to the startup script.
         
         !!! note
@@ -398,6 +399,9 @@ class VirtualDriveManager(IUefiHelperPlugin):
                 tests.append(f"    mv {test.stem}_JUNIT.XML {test.stem}_JUNIT_RESULT.XML")
                 tests.append("endif")
             
+            if paging_audit:
+                tests.append("DxePagingAuditTestApp.efi -d")
+            
         drive.add_startup_script(tests, auto_shutdown = auto_shutdown)
     
     @staticmethod
@@ -436,3 +440,23 @@ class VirtualDriveManager(IUefiHelperPlugin):
                 logging.error("Exception trying to read xml." + str(ex))
                 failure_count += 1
         return failure_count
+    
+    @staticmethod
+    def generate_paging_audit(drive: VirtualDrive, report_output_dir: Path, version: str):
+        paging_audit_data_files = ["1G.dat", "2M.dat", "4K.dat", "PDE.dat", "MAT.dat",
+                                   "GuardPage.dat", "MemoryInfoDatabase.dat"]
+        paging_audit_generator_path = os.path.join("Common", "MU", "UefiTestingPkg", "AuditTests",
+                                                   "PagingAudit", "Windows", "PagingReportGenerator.py")
+
+        for file in paging_audit_data_files:
+            drive.get_file(file, os.path.join(report_output_dir, file))
+        output_audit = os.path.join(report_output_dir, "pagingaudit.html")
+        output_debug = os.path.join(report_output_dir, "pagingauditdebug.txt")
+        cmd = "python"
+        args = f"{paging_audit_generator_path} -i {report_output_dir} -o {output_audit} \
+-p Q35 -t DXE --debug -l {output_debug} -a X64 --PlatformVersion {version}"
+        result = RunCmd(cmd, args)
+        if result != 0:
+            e = f"[{cmd} {args}] Result: {result}"
+            logger.error("Drive could not be created.")
+            logger.error(e)


### PR DESCRIPTION
## Description

Add a step when adding unit tests to the startup.nsh file to add a second run of DxePagingAuditTestApp with the '-d' parameter to dump the paging audit files. When reporting results, extract the paging audit files and create the audit.

With this update, every CI run will contain the paging audit in the artifacts. Also, whenever DxePagingAuditTestApp.efi is included in a Q35 or SBSA TEST_REGEX, the paging audit will be created and deposited into the unit_test_results folder.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Build and run on SBSA and Q35

## Integration Instructions

N/A