### PR TITLE
Add POPCNT option to Q35 CPU

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -100,7 +100,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -hda \"" + env.GetValue("PATH_TO_OS") + "\""
         else:
             args += " -m 2048"
-        args += " -cpu qemu64,+rdrand,umip,+smep" # most compatible x64 CPU model + RDRAND + UMIP + SMEP support (not included by default)
+        args += " -cpu qemu64,+rdrand,umip,+smep,+popcnt" # most compatible x64 CPU model + RDRAND + UMIP + SMEP + POPCNT support (not included by default)
         if env.GetBuildValue ("QEMU_CORE_NUM") is not None:
             args += " -smp " + env.GetBuildValue ("QEMU_CORE_NUM")
         if smm_enabled == "on":


### PR DESCRIPTION
## Description

Windows Builds 25855+ require the POPCNT CPU feature. This PR adds this option to the Q35 CPU options when launching QEMU to ensure compatibility.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Windows boot locally.

## Integration Instructions

N/A
