### PR TITLE
Allow TEST_REGEX without RUN_TESTS=TRUE

### DIFF
--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -368,9 +368,9 @@ class VirtualDriveManager(IUefiHelperPlugin):
             auto_shutdown (Boolean): Whether or not to shutdown after tests have completed.
         """
         drive.add_files(test_list)
+        tests = []
 
         if auto_run:
-            tests = []
             # Execute all tests
             tests.append("# 1. We conditionally run a test based off of the presence of a <TestName>_JUNIT.XML. When this file is")
             tests.append("#    present, it means that the test has completely finished and the results have been recorded. Once the")


### PR DESCRIPTION
Allow a user to specify TEST_REGEX=<regex> without RUN_TESTS=TRUE. This enables users to have tests added to the virtual drive without without updating the startup script. This is for scenarios where users want to run the tests manually.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
