### PR TITLE
Bump MU_BASECORE from 2022080002.0.1 to 2022080002.0.2

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1267,7 +1267,7 @@
       gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0xFF
   }
 
-  PolicyServicePkg/PolicyService/Dxe/PolicyDxe.inf
+  PolicyServicePkg/PolicyService/DxeMm/PolicyDxe.inf
 
   SetupDataPkg/ConfApp/ConfApp.inf {
     <LibraryClasses>

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -417,7 +417,7 @@ INF  QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
   INF  NetworkPkg/TcpDxe/TcpDxe.inf
   INF  NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
 
-  INF  PolicyServicePkg/PolicyService/Dxe/PolicyDxe.inf
+  INF  PolicyServicePkg/PolicyService/DxeMm/PolicyDxe.inf
   INF  SetupDataPkg/ConfApp/ConfApp.inf
 
   INF  NetworkPkg/TlsDxe/TlsDxe.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1094,7 +1094,7 @@
   PcBdsPkg/MsBootPolicy/MsBootPolicy.inf
 
   # Configuration modules
-  PolicyServicePkg/PolicyService/Dxe/PolicyDxe.inf
+  PolicyServicePkg/PolicyService/DxeMm/PolicyDxe.inf
 
   SetupDataPkg/ConfApp/ConfApp.inf {
     <LibraryClasses>

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -289,7 +289,7 @@ READ_LOCK_STATUS   = TRUE
   #
   # Policy and configuration
   #
-  INF PolicyServicePkg/PolicyService/Dxe/PolicyDxe.inf
+  INF PolicyServicePkg/PolicyService/DxeMm/PolicyDxe.inf
 
   #
   # Frontpages


### PR DESCRIPTION
Bumps MU_BASECORE from `2022080002.0.1` to `2022080002.0.2`


Introduces 10 new commits in [MU_BASECORE](https://github.com/microsoft/mu_basecore.git).

<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/microsoft/mu_basecore/commit/a296f04604fd32db6d862646f3dd25ba2d5514e2">a296f0</a> Introduce Standalone MM Policy Service (<a href="https://github.com/microsoft/mu_basecore/pull/390">#390</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/d4d7856f93bdcfdb785a81aa3830d8e871f6b113">d4d785</a> Add basic wrappers to the Policy Library (<a href="https://github.com/microsoft/mu_basecore/pull/396">#396</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/68f1e801de4c8f1ab970ffb331eb8d4efd69ab9b">68f1e8</a> pip: update edk2-pytool-extensions requirement from ~=0.23.0 to ~=0.23.2 (<a href="https://github.com/microsoft/mu_basecore/pull/397">#397</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/346e17b532854248bf6378b70075142e4751bff8">346e17</a> pip: bump edk2-basetools from 0.1.45 to 0.1.48 (<a href="https://github.com/microsoft/mu_basecore/pull/401">#401</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/19a366b2b3272bc6031fbab65ad1326085f2303c">19a366</a> Create Github Workflow to publish basetools on release (<a href="https://github.com/microsoft/mu_basecore/pull/385">#385</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/656456cd5fcd0f104e9a8813b953b1ab7492cc71">656456</a> Additional CodeQL Fixes (<a href="https://github.com/microsoft/mu_basecore/pull/400">#400</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/01a4ed58fbb9c284fa254ec5b04be4febd8a0c9d">01a4ed</a> pip: update edk2-pytool-library requirement from ~=0.14.1 to ~=0.15.0 (<a href="https://github.com/microsoft/mu_basecore/pull/405">#405</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/f421222215ad57feed9bd29a38ff61e13adcf2df">f42122</a> pip: bump antlr4-python3-runtime from 4.12.0 to 4.13.0 (<a href="https://github.com/microsoft/mu_basecore/pull/408">#408</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/c03dc558c048af7863b7d7e30fbf2e34b5b53c51">c03dc5</a> pip: update edk2-pytool-extensions requirement from ~=0.23.2 to ~=0.23.3 (<a href="https://github.com/microsoft/mu_basecore/pull/406">#406</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/3179184b360bb7ad2dc979f45cddb242d6b995c3">317918</a> [CHERRY-PICK] Stop USB enumeration in case a malformed descriptor is found (<a href="https://github.com/microsoft/mu_basecore/pull/410">#410</a>) (<a href="https://github.com/microsoft/mu_basecore/pull/412">#412</a>)</li>
</ul>
</details>

Signed-off-by: Project Mu Bot <mubot@microsoft.com>