### PR TITLE
Release.yaml: Update to work with self-hosted agent change

### DIFF
--- a/.azurepipelines/Release.yml
+++ b/.azurepipelines/Release.yml
@@ -17,35 +17,171 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v2.5.2
+      ref: main
 
 name: $(Date:yyyyMMdd)$(Rev:.r) Mu Tiano Platforms Release
 
 stages:
-- stage: BuildQemuPlatforms
-  displayName: Build QEMU Platforms
+- stage: LinuxBuildQemuPlatforms
+  displayName: Build QEMU Platforms on Linux
+
+  variables:
+  - group: tool-chain-ubuntu-gcc
+
   jobs:
     - template: Platform-Build-Job.yml
       parameters:
-          extra_install_step:
-                - script: sudo dnf --assumeyes install openssl-devel
-                  displayName: Install openssl
-          container_image: ghcr.io/tianocore/containers/fedora-37-test:54e5bd1
-          tool_chain_tag: GCC5
-          vm_image: ubuntu-latest
+        tool_chain_tag: 'GCC5'
+        vm_image: ubuntu-latest
+        os_type: Linux
+        container_image: ghcr.io/tianocore/containers/fedora-37-test:latest
+        build_matrix:
+          QemuQ35_GCC_DEBUG:
+            BuildPackage: QemuQ35Pkg
+            BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
+            BuildArch: IA32,X64
+            BuildFlags: ""
+            BuildTarget: "DEBUG"
+            BuildExtraTag: ""
+            BuildExtraStep:
+              - script: echo No extra steps provided
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
+            BuildArtifactsBinary: |
+              **/QEMUQ35_*.fd
+            BuildArtifactsOther: "**/unit_test_results/*"
 
+          QemuQ35_GCC_RELEASE:
+            BuildPackage: QemuQ35Pkg
+            BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
+            BuildArch: IA32,X64
+            BuildFlags: ""
+            BuildTarget: "RELEASE"
+            BuildExtraTag: ""
+            BuildExtraStep:
+              - script: echo No extra steps provided
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
+            BuildArtifactsBinary: |
+              **/QEMUQ35_*.fd
+            BuildArtifactsOther: "**/unit_test_results/*"
+
+          QemuQ35_GCC_NO_SMM_RELEASE:
+            BuildPackage: QemuQ35Pkg
+            BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
+            BuildArch: IA32,X64
+            BuildFlags: "BLD_*_SMM_ENABLED=FALSE"
+            BuildTarget: "RELEASE"
+            BuildExtraTag: "NO_SMM"
+            BuildExtraStep:
+              - script: echo No extra steps provided
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE BLD_*_QEMU_CORE_NUM=2 BLD_*_SMM_ENABLED=FALSE"
+            BuildArtifactsBinary: |
+              **/QEMUQ35_*.fd
+            BuildArtifactsOther: ""
+
+          QemuSbsa_GCC_DEBUG:
+            BuildPackage: QemuSbsaPkg
+            BuildFile: "Platforms/QemuSbsaPkg/PlatformBuild.py"
+            BuildArch: AARCH64
+            BuildFlags: ""
+            BuildTarget: "DEBUG"
+            BuildExtraTag: ""
+            BuildExtraStep:
+              - script: sudo dnf --assumeyes install openssl-devel
+                displayName: Install openssl
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
+            BuildArtifactsBinary: |
+              **/QEMU_EFI.fd
+              **/SECURE_FLASH0.fd
+            BuildArtifactsOther: "**/unit_test_results/*"
+
+          QemuSbsa_GCC_RELEASE:
+            BuildPackage: QemuSbsaPkg
+            BuildFile: "Platforms/QemuSbsaPkg/PlatformBuild.py"
+            BuildArch: AARCH64
+            BuildFlags: ""
+            BuildTarget: "RELEASE"
+            BuildExtraTag: ""
+            BuildExtraStep:
+              - script: sudo dnf --assumeyes install openssl-devel
+                displayName: Install openssl
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
+            BuildArtifactsBinary: |
+              **/QEMU_EFI.fd
+              **/SECURE_FLASH0.fd
+            BuildArtifactsOther: "**/unit_test_results/*"
+
+- stage: WindowsBuildQemuPlatforms
+  displayName: Build QEMU Platforms on Windows
+  dependsOn: []
+
+  variables:
+  - group: tool-chain-windows-visual-studio-latest
+
+  jobs:
     - template: Platform-Build-Job.yml
       parameters:
-          extra_install_step:
-          - powershell: choco install qemu --version=2022.8.31; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
-            displayName: Install QEMU and Set QEMU on path
-            condition: and(gt(variables.pkg_count, 0), succeeded())
-          tool_chain_tag: VS2022
-          vm_image: windows-latest
+        extra_install_step:
+        - powershell: choco install qemu --version=2022.8.31; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+          displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
+          condition: and(gt(variables.pkg_count, 0), succeeded())
+        tool_chain_tag: 'VS2022'
+        vm_image: windows-latest
+        os_type: Windows_NT
+        build_matrix:
+          QemuQ35_VS_DEBUG:
+            BuildPackage: QemuQ35Pkg
+            BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
+            BuildArch: IA32,X64
+            BuildFlags: ""
+            BuildTarget: "DEBUG"
+            BuildExtraTag: ""
+            BuildExtraStep:
+              - script: echo No extra steps provided
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
+            BuildArtifactsBinary: |
+              **/QEMUQ35_*.fd
+            BuildArtifactsOther: "**/unit_test_results/*"
+
+          QemuQ35_VS_RELEASE:
+            BuildPackage: QemuQ35Pkg
+            BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
+            BuildArch: IA32,X64
+            BuildFlags: ""
+            BuildTarget: "RELEASE"
+            BuildExtraTag: ""
+            BuildExtraStep:
+              - script: echo No extra steps provided
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
+            BuildArtifactsBinary: |
+              **/QEMUQ35_*.fd
+            BuildArtifactsOther: "**/unit_test_results/*"
+
+          QemuQ35_VS_NO_SMM_RELEASE:
+            BuildPackage: QemuQ35Pkg
+            BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
+            BuildArch: IA32,X64
+            BuildFlags: "BLD_*_SMM_ENABLED=FALSE"
+            BuildTarget: "RELEASE"
+            BuildExtraTag: "NO_SMM"
+            BuildExtraStep:
+              - script: echo No extra steps provided
+            Run: true
+            RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE BLD_*_QEMU_CORE_NUM=2 BLD_*_SMM_ENABLED=FALSE"
+            BuildArtifactsBinary: |
+              **/QEMUQ35_*.fd
+            BuildArtifactsOther: ""
 
 - stage: PublishReleaseArtifacts
   displayName: Publish Release Artifacts
   dependsOn:
-  - BuildQemuPlatforms
+  - LinuxBuildQemuPlatforms
+  - WindowsBuildQemuPlatforms
   jobs:
     - template: templates/Job-Publish.yml


### PR DESCRIPTION
## Description

- Updates the pipeline to pass a matrix object to the `Platform-Build-Job.yml`
  template.
- Uses the `main` branch of `mu_devops` instead of a version since the version
  is not automatically updated in this file and tends to drift out-of-date.

## How This Was Tested

Performed a test release on a mu_devops fork.

## Integration Instructions

N/A - No user visible changes