### PR TITLE
Set the Type3 SN different from the Type1 SN

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -166,7 +166,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         args += " -smbios type=0,vendor=Palindrome,uefi=on"
         args += " -smbios type=1,manufacturer=Palindrome,product=MuQemuQ35,serial=42-42-42-42,uuid=9de555c0-05d7-4aa1-84ab-bb511e3a8bef"
-        args += f" -smbios type=3,manufacturer=Palindrome,serial=42-42-42-42{boot_selection}"
+        args += f" -smbios type=3,manufacturer=Palindrome,serial=40-41-42-43{boot_selection}"
 
         if (env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):
             args += " -display none"  # no graphics


### PR DESCRIPTION
## Description

Set the Type 1 and Type 3 serial numbers to different values.  This allows one to see the that UI App has chosen the correct serial number to display.  It also is the source for the Type 1 serial number that DfciDeviceIdLib uses to inform InTune of the device Serial Number.  The latest test cases will verify the correct serial number.

Used in testing Issue microsoft/mu_oem_sample#102 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Potentially a code break if the wrong serial number has been used in the past.
- [x] Includes tests?
  - **Tests** - The latest Dfci Test cases will verify the correct serial number.
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on QemuQ35Plg

## Integration Instructions

N/A
