### PR TITLE
mu_oem_sample and mu_feature_config submodule update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
 	branch = release/202302
 [submodule "Common/MU_OEM_SAMPLE"]
 	path = Common/MU_OEM_SAMPLE
-	url = https://github.com/microsoft/mu_oem_sample.git
-	branch = release/202302
+	url = https://github.com/kuqin12/mu_oem_sample.git
+	branch = oem_config_udpate
 [submodule "Silicon/Arm/MU_TIANO"]
 	path = Silicon/Arm/MU_TIANO
 	url = https://github.com/microsoft/mu_silicon_arm_tiano.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
 	branch = release/202302
 [submodule "Common/MU_OEM_SAMPLE"]
 	path = Common/MU_OEM_SAMPLE
-	url = https://github.com/kuqin12/mu_oem_sample.git
-	branch = oem_config_udpate
+	url = https://github.com/microsoft/mu_oem_sample.git
+	branch = release/202302
 [submodule "Silicon/Arm/MU_TIANO"]
 	path = Silicon/Arm/MU_TIANO
 	url = https://github.com/microsoft/mu_silicon_arm_tiano.git

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -47,15 +47,14 @@ GFX_POLICY_DATA  DefaultQemuGfxPolicy[GFX_PORT_MAX_CNT] = {
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  VOID        *ConfigBuffer
+  IN  VOID  *ConfigBuffer
   )
 {
   EFI_STATUS       Status;
   BOOLEAN          GfxEnablePort0;
   GFX_POLICY_DATA  *GfxSiliconPolicy;
 
-  if (ConfigBuffer == NULL)
-  {
+  if (ConfigBuffer == NULL) {
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -8,10 +8,7 @@
 
 #include <Uefi.h>
 #include <PolicyDataStructGFX.h>
-#include <Protocol/Policy.h>
 
-#include <Ppi/ReadOnlyVariable2.h>
-#include <Ppi/Policy.h>
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -20,6 +17,7 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
+#include <Library/PolicyLib.h>
 #include <Library/MemoryAllocationLib.h>
 
 // XML autogen definitions
@@ -36,51 +34,6 @@ GFX_POLICY_DATA  DefaultQemuGfxPolicy[GFX_PORT_MAX_CNT] = {
 };
 
 /**
-  Helper function to translate GFX configuration data to GFX silicon policy.
-
-  @param[in]      PolicyInterface   Pointer to current policy protocol/PPI interface.
-  @param[in]      PlatformGfxPowerOnPort0 Value of PowerOnPort0 config knob.
-  @param[out]     GfxSiliconPolicy  Pointer to hold translated GFX silicon policy.
-  @param[in]      PolicySize        The available size of GfxSiliconPolicy,
-
-  @retval EFI_SUCCESS           The configuration is translated to policy successfully.
-  @retval EFI_INVALID_PARAMETER One or more of the required input pointers are NULL.
-  @retval EFI_BUFFER_TOO_SMALL  Supplied GfxSiliconPolicy is too small to fit in translated data.
-  @retval Others                Other errors occurred when getting GFX policy.
-**/
-STATIC
-EFI_STATUS
-ConvertGfxPolicyFromConfData (
-  IN      POLICY_PROTOCOL  *PolicyInterface,
-  IN      BOOLEAN          PlatformGfxPowerOnPort0,
-  OUT     GFX_POLICY_DATA  *GfxSiliconPolicy,
-  IN      UINT16           *PolicySize
-  )
-{
-  EFI_STATUS  Status;
-
-  if ((PolicyInterface == NULL) || (PolicySize == NULL) ||
-      (GfxSiliconPolicy == NULL) || (*PolicySize == 0))
-  {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (*PolicySize < GFX_POLICY_SIZE) {
-    return EFI_BUFFER_TOO_SMALL;
-  }
-
-  Status = PolicyInterface->GetPolicy (&gPolicyDataGFXGuid, NULL, GfxSiliconPolicy, PolicySize);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  // We only translate the GFX ports #0 exposed to platform from conf data
-  GfxSiliconPolicy[0].Power_State_Port = PlatformGfxPowerOnPort0;
-
-  return EFI_SUCCESS;
-}
-
-/**
   Helper function to apply GFX configuration data to GFX silicon policy.
 
   @param[in]      PolicyInterface   Pointer to current policy protocol/PPI interface.
@@ -94,20 +47,14 @@ ConvertGfxPolicyFromConfData (
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  POLICY_PPI  *PolicyInterface,
   IN  VOID        *ConfigBuffer
   )
 {
-  EFI_STATUS  Status;
-  UINT16      Size;
-  UINT64      Attr = 0;
-
+  EFI_STATUS       Status;
   BOOLEAN          GfxEnablePort0;
-  GFX_POLICY_DATA  GfxSiPol[GFX_PORT_MAX_CNT];
-  GFX_POLICY_DATA  GfxConfPol[GFX_PORT_MAX_CNT];
+  GFX_POLICY_DATA  *GfxSiliconPolicy;
 
-  if ((PolicyInterface == NULL) ||
-      (ConfigBuffer == NULL))
+  if (ConfigBuffer == NULL)
   {
     return EFI_INVALID_PARAMETER;
   }
@@ -115,29 +62,17 @@ ApplyGfxConfigToPolicy (
   DEBUG ((DEBUG_INFO, "%a Entry...\n", __FUNCTION__));
 
   // query autogen header to get config knob value
-  GfxEnablePort0 = *(BOOLEAN *)ConfigBuffer;
-  Size           = sizeof (GfxSiPol);
-  Status         = PolicyInterface->GetPolicy (&gPolicyDataGFXGuid, &Attr, GfxSiPol, &Size);
+  GfxEnablePort0   = *(BOOLEAN *)ConfigBuffer;
+  GfxSiliconPolicy = AllocateCopyPool (sizeof (DefaultQemuGfxPolicy), DefaultQemuGfxPolicy);
+
+  // We only translate the GFX ports #0 exposed to platform from conf data
+  GfxSiliconPolicy[0].Power_State_Port = GfxEnablePort0;
+
+  Status = SetPolicy (&gPolicyDataGFXGuid, POLICY_ATTRIBUTE_FINALIZED, GfxSiliconPolicy, sizeof (DefaultQemuGfxPolicy));
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a Failed to get GFX policy - %r!!!\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a Failed to update GFX policy per configuration data - %r!!!\n", __func__, Status));
     ASSERT (FALSE);
     goto Exit;
-  }
-
-  Status = ConvertGfxPolicyFromConfData (PolicyInterface, GfxEnablePort0, GfxConfPol, &Size);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a Failed to convert GFX configuration to policy - %r!!!\n", __FUNCTION__, Status));
-    ASSERT (FALSE);
-    goto Exit;
-  }
-
-  if (CompareMem (GfxConfPol, GfxSiPol, Size) != 0) {
-    Status = PolicyInterface->SetPolicy (&gPolicyDataGFXGuid, (Attr | POLICY_ATTRIBUTE_FINALIZED), GfxConfPol, Size);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a Failed to update GFX policy per configuration data - %r!!!\n", __FUNCTION__, Status));
-      ASSERT (FALSE);
-      goto Exit;
-    }
   }
 
 Exit:

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.c
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.c
@@ -9,12 +9,11 @@
 #include <Uefi.h>
 #include <PolicyDataStructGFX.h>
 
-#include <Ppi/Policy.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/PeiServicesLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
+#include <Library/PolicyLib.h>
 #include <ConfigStdStructDefs.h>
 
 // XML autogen definitions
@@ -39,19 +38,9 @@ ConfigKnobsEntry (
   )
 {
   EFI_STATUS  Status;
-  POLICY_PPI  *PolPpi = NULL;
-
-  BOOLEAN  GfxEnablePort0;
+  BOOLEAN     GfxEnablePort0;
 
   DEBUG ((DEBUG_INFO, "%a - Entry.\n", __FUNCTION__));
-
-  // First locate policy ppi, should not fail as we populate the
-  Status = PeiServicesLocatePpi (&gPeiPolicyPpiGuid, 0, NULL, (VOID *)&PolPpi);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a Failed to locate Policy PPI - %r\n", __FUNCTION__, Status));
-    ASSERT (FALSE);
-    goto Done;
-  }
 
   Status = ConfigGetPowerOnPort0 (&GfxEnablePort0);
   if (EFI_ERROR (Status)) {
@@ -60,7 +49,7 @@ ConfigKnobsEntry (
     goto Done;
   }
 
-  Status = ApplyGfxConfigToPolicy (PolPpi, &GfxEnablePort0);
+  Status = ApplyGfxConfigToPolicy (&GfxEnablePort0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to apply configuration data to the GFX silicon policy - %r\n", __FUNCTION__, Status));
     ASSERT (FALSE);

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.h
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.h
@@ -12,7 +12,6 @@
 /**
   Helper function to apply GFX configuration data to GFX silicon policy.
 
-  @param[in]      PolicyInterface   Pointer to current policy protocol/PPI interface.
   @param[in]      GfxConfigBuffer   Pointer to GFX configuration data.
 
   @retval EFI_SUCCESS           The configuration is translated to policy successfully.
@@ -23,7 +22,6 @@
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  POLICY_PPI  *PolicyInterface,
   IN  VOID        *ConfigBuffer
   );
 

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.h
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.h
@@ -22,7 +22,7 @@
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  VOID        *ConfigBuffer
+  IN  VOID  *ConfigBuffer
   );
 
 #endif // CONFIG_KNOBS_H_

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.inf
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigKnobs.inf
@@ -34,9 +34,10 @@
   PeiServicesLib
   PrintLib
   PcdLib
+  PolicyLib
 
 [Guids]
-  gPolicyDataGFXGuid                            # CONSUMES
+  gPolicyDataGFXGuid                ## CONSUMES
   gOemConfigPolicyGuid              ## CONSUMES
 
 [Ppis]

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -282,6 +282,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
                           self.mws.join(self.ws, 'Platforms', 'QemuQ35Pkg', 'CfgData', 'Profile1QemuQ35PkgCfgData.csv'),
                           "Platform Hardcoded"
         )
+        self.env.SetValue('CONF_PROFILE_NAMES', "P0,P1", "Platform Hardcoded")
 
         # Globally set CodeQL failures to be ignored in this repo.
         # Note: This has no impact if CodeQL is not active/enabled.

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -437,6 +437,7 @@
   PcdDatabaseLoaderLib       |MdeModulePkg/Library/PcdDatabaseLoaderLib/Pei/PcdDatabaseLoaderLibPei.inf
   OemMfciLib                 |OemPkg/Library/OemMfciLib/OemMfciLibPei.inf
   ConfigKnobShimLib          |SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/ConfigKnobShimPeiLib.inf
+  PolicyLib                  |PolicyServicePkg/Library/PeiPolicyLib/PeiPolicyLib.inf
 !if $(SOURCE_DEBUG_ENABLE) == TRUE
   DebugAgentLib              |SourceLevelDebugPkg/Library/DebugAgent/SecPeiDebugAgentLib.inf
 !endif
@@ -512,6 +513,7 @@
   UpdateFacsHardwareSignatureLib|OemPkg/Library/UpdateFacsHardwareSignatureLib/UpdateFacsHardwareSignatureLib.inf
   PcdDatabaseLoaderLib|MdeModulePkg/Library/PcdDatabaseLoaderLib/Dxe/PcdDatabaseLoaderLibDxe.inf
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+  PolicyLib|PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
 !if $(SOURCE_DEBUG_ENABLE) == TRUE
   DebugAgentLib|SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgentLib.inf
 !endif

--- a/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -46,15 +46,14 @@ GFX_POLICY_DATA  DefaultQemuGfxPolicy[GFX_PORT_MAX_CNT] = {
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  VOID        *ConfigBuffer
+  IN  VOID  *ConfigBuffer
   )
 {
   EFI_STATUS       Status;
   BOOLEAN          GfxEnablePort0;
   GFX_POLICY_DATA  *GfxSiliconPolicy;
 
-  if (ConfigBuffer == NULL)
-  {
+  if (ConfigBuffer == NULL) {
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -8,10 +8,7 @@
 
 #include <Uefi.h>
 #include <PolicyDataStructGFX.h>
-#include <Protocol/Policy.h>
 
-#include <Ppi/ReadOnlyVariable2.h>
-#include <Ppi/Policy.h>
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -20,6 +17,7 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
+#include <Library/PolicyLib.h>
 #include <Library/MemoryAllocationLib.h>
 
 // XML autogen definitions
@@ -38,7 +36,6 @@ GFX_POLICY_DATA  DefaultQemuGfxPolicy[GFX_PORT_MAX_CNT] = {
 /**
   Helper function to apply GFX configuration data to GFX silicon policy.
 
-  @param[in]      PolicyInterface   Pointer to current policy protocol/PPI interface.
   @param[in]      GfxConfigBuffer   Pointer to GFX configuration data.
 
   @retval EFI_SUCCESS           The configuration is translated to policy successfully.
@@ -49,7 +46,6 @@ GFX_POLICY_DATA  DefaultQemuGfxPolicy[GFX_PORT_MAX_CNT] = {
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  POLICY_PPI  *PolicyInterface,
   IN  VOID        *ConfigBuffer
   )
 {
@@ -57,8 +53,7 @@ ApplyGfxConfigToPolicy (
   BOOLEAN          GfxEnablePort0;
   GFX_POLICY_DATA  *GfxSiliconPolicy;
 
-  if ((PolicyInterface == NULL) ||
-      (ConfigBuffer == NULL))
+  if (ConfigBuffer == NULL)
   {
     return EFI_INVALID_PARAMETER;
   }

--- a/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -36,51 +36,6 @@ GFX_POLICY_DATA  DefaultQemuGfxPolicy[GFX_PORT_MAX_CNT] = {
 };
 
 /**
-  Helper function to translate GFX configuration data to GFX silicon policy.
-
-  @param[in]      PolicyInterface   Pointer to current policy protocol/PPI interface.
-  @param[in]      PlatformGfxPowerOnPort0 Value of PowerOnPort0 config knob.
-  @param[out]     GfxSiliconPolicy  Pointer to hold translated GFX silicon policy.
-  @param[in]      PolicySize        The available size of GfxSiliconPolicy,
-
-  @retval EFI_SUCCESS           The configuration is translated to policy successfully.
-  @retval EFI_INVALID_PARAMETER One or more of the required input pointers are NULL.
-  @retval EFI_BUFFER_TOO_SMALL  Supplied GfxSiliconPolicy is too small to fit in translated data.
-  @retval Others                Other errors occurred when getting GFX policy.
-**/
-STATIC
-EFI_STATUS
-ConvertGfxPolicyFromConfData (
-  IN      POLICY_PROTOCOL  *PolicyInterface,
-  IN      BOOLEAN          PlatformGfxPowerOnPort0,
-  OUT     GFX_POLICY_DATA  *GfxSiliconPolicy,
-  IN      UINT16           *PolicySize
-  )
-{
-  EFI_STATUS  Status;
-
-  if ((PolicyInterface == NULL) || (PolicySize == NULL) ||
-      (GfxSiliconPolicy == NULL) || (*PolicySize == 0))
-  {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (*PolicySize < GFX_POLICY_SIZE) {
-    return EFI_BUFFER_TOO_SMALL;
-  }
-
-  Status = PolicyInterface->GetPolicy (&gSbsaPolicyDataGFXGuid, NULL, GfxSiliconPolicy, PolicySize);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  // We only translate the GFX ports #0 exposed to platform from conf data
-  GfxSiliconPolicy[0].Power_State_Port = PlatformGfxPowerOnPort0;
-
-  return EFI_SUCCESS;
-}
-
-/**
   Helper function to apply GFX configuration data to GFX silicon policy.
 
   @param[in]      PolicyInterface   Pointer to current policy protocol/PPI interface.
@@ -98,13 +53,9 @@ ApplyGfxConfigToPolicy (
   IN  VOID        *ConfigBuffer
   )
 {
-  EFI_STATUS  Status;
-  UINT16      Size;
-  UINT64      Attr = 0;
-
+  EFI_STATUS       Status;
   BOOLEAN          GfxEnablePort0;
-  GFX_POLICY_DATA  GfxSiPol[GFX_PORT_MAX_CNT];
-  GFX_POLICY_DATA  GfxConfPol[GFX_PORT_MAX_CNT];
+  GFX_POLICY_DATA  *GfxSiliconPolicy;
 
   if ((PolicyInterface == NULL) ||
       (ConfigBuffer == NULL))
@@ -112,34 +63,23 @@ ApplyGfxConfigToPolicy (
     return EFI_INVALID_PARAMETER;
   }
 
-  DEBUG ((DEBUG_INFO, "%a Entry...\n", __FUNCTION__));
+  DEBUG ((DEBUG_INFO, "%a Entry...\n", __func__));
 
   // query autogen header to get config knob value
-  GfxEnablePort0 = *(BOOLEAN *)ConfigBuffer;
-  Size           = sizeof (GfxSiPol);
-  Status         = PolicyInterface->GetPolicy (&gSbsaPolicyDataGFXGuid, &Attr, GfxSiPol, &Size);
+  GfxEnablePort0   = *(BOOLEAN *)ConfigBuffer;
+  GfxSiliconPolicy = AllocateCopyPool (sizeof (DefaultQemuGfxPolicy), DefaultQemuGfxPolicy);
+
+  // We only translate the GFX ports #0 exposed to platform from conf data
+  GfxSiliconPolicy[0].Power_State_Port = GfxEnablePort0;
+
+  Status = SetPolicy (&gSbsaPolicyDataGFXGuid, POLICY_ATTRIBUTE_FINALIZED, GfxSiliconPolicy, sizeof (DefaultQemuGfxPolicy));
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a Failed to get GFX policy - %r!!!\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a Failed to update GFX policy per configuration data - %r!!!\n", __func__, Status));
     ASSERT (FALSE);
     goto Exit;
-  }
-
-  Status = ConvertGfxPolicyFromConfData (PolicyInterface, GfxEnablePort0, GfxConfPol, &Size);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a Failed to convert GFX configuration to policy - %r!!!\n", __FUNCTION__, Status));
-    ASSERT (FALSE);
-    goto Exit;
-  }
-
-  if (CompareMem (GfxConfPol, GfxSiPol, Size) != 0) {
-    Status = PolicyInterface->SetPolicy (&gSbsaPolicyDataGFXGuid, (Attr | POLICY_ATTRIBUTE_FINALIZED), GfxConfPol, Size);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a Failed to update GFX policy per configuration data - %r!!!\n", __FUNCTION__, Status));
-      ASSERT (FALSE);
-      goto Exit;
-    }
   }
 
 Exit:
+  DEBUG ((DEBUG_INFO, "%a Exit - %r\n", __func__, Status));
   return Status;
 }

--- a/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.c
+++ b/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.c
@@ -9,12 +9,12 @@
 #include <Uefi.h>
 #include <PolicyDataStructGFX.h>
 
-#include <Ppi/Policy.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
+#include <Library/PolicyLib.h>
 #include <ConfigStdStructDefs.h>
 
 // XML autogen definitions
@@ -39,19 +39,10 @@ ConfigKnobsEntry (
   )
 {
   EFI_STATUS  Status;
-  POLICY_PPI  *PolPpi = NULL;
 
   BOOLEAN  GfxEnablePort0;
 
   DEBUG ((DEBUG_INFO, "%a - Entry.\n", __FUNCTION__));
-
-  // First locate policy ppi, should not fail as we populate the
-  Status = PeiServicesLocatePpi (&gPeiPolicyPpiGuid, 0, NULL, (VOID *)&PolPpi);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a Failed to locate Policy PPI - %r\n", __FUNCTION__, Status));
-    ASSERT (FALSE);
-    goto Done;
-  }
 
   Status = ConfigGetPowerOnPort0 (&GfxEnablePort0);
   if (EFI_ERROR (Status)) {
@@ -60,7 +51,7 @@ ConfigKnobsEntry (
     goto Done;
   }
 
-  Status = ApplyGfxConfigToPolicy (PolPpi, &GfxEnablePort0);
+  Status = ApplyGfxConfigToPolicy (&GfxEnablePort0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to apply configuration data to the GFX silicon policy - %r\n", __FUNCTION__, Status));
     ASSERT (FALSE);

--- a/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.h
+++ b/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.h
@@ -12,7 +12,6 @@
 /**
   Helper function to apply GFX configuration data to GFX silicon policy.
 
-  @param[in]      PolicyInterface   Pointer to current policy protocol/PPI interface.
   @param[in]      GfxConfigBuffer   Pointer to GFX configuration data.
 
   @retval EFI_SUCCESS           The configuration is translated to policy successfully.
@@ -23,7 +22,6 @@
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  POLICY_PPI  *PolicyInterface,
   IN  VOID        *ConfigBuffer
   );
 

--- a/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.h
+++ b/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.h
@@ -22,7 +22,7 @@
 EFI_STATUS
 EFIAPI
 ApplyGfxConfigToPolicy (
-  IN  VOID        *ConfigBuffer
+  IN  VOID  *ConfigBuffer
   );
 
 #endif // CONFIG_KNOBS_H_

--- a/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.inf
+++ b/Platforms/QemuSbsaPkg/ConfigKnobs/ConfigKnobs.inf
@@ -34,6 +34,7 @@
   PeiServicesLib
   PrintLib
   PcdLib
+  PolicyLib
 
 [Guids]
   gSbsaPolicyDataGFXGuid            ## CONSUMES

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -431,6 +431,7 @@
   ArmPlatformLib             |QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuLib.inf
   OemMfciLib                 |OemPkg/Library/OemMfciLib/OemMfciLibPei.inf
   ConfigKnobShimLib          |SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/ConfigKnobShimPeiLib.inf
+  PolicyLib                  |PolicyServicePkg/Library/PeiPolicyLib/PeiPolicyLib.inf
 
 !if $(TPM2_ENABLE) == TRUE
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
@@ -453,6 +454,7 @@
   PcdDatabaseLoaderLib|MdeModulePkg/Library/PcdDatabaseLoaderLib/Dxe/PcdDatabaseLoaderLibDxe.inf
   UpdateFacsHardwareSignatureLib|OemPkg/Library/UpdateFacsHardwareSignatureLib/UpdateFacsHardwareSignatureLib.inf
   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
+  PolicyLib|PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
 
 !if $(TPM2_ENABLE) == TRUE
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Update OEM sample repo to **v2023020000.0.2** and mu_feature_config repo to **v0.3.4** for mu_tiano_platforms.

The corresponding configuration module usage is also simplified to pair with the submodule changes.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested locally on Q35 and SBSA.

## Integration Instructions

Added a new configuration build variable for profile names on Q35 platform.