### PR TITLE
QemuRunner: Add support for QCOW2 images

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -16,6 +16,7 @@ import subprocess
 import re
 import io
 import shutil
+from pathlib import Path
 from edk2toolext.environment import plugin_manager
 from edk2toolext.environment.plugintypes import uefi_helper_plugin
 from edk2toollib import utility_functions
@@ -91,10 +92,12 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # Potentially dealing with big daddy, give it more juice...
             args += " -m 8192"
 
+            file_extension = Path(path_to_os).suffix.lower().replace('"', '')
+            
             storage_rule = {
-                ".vhd": " -drive format=raw,index=0,media=disk,file=\"" + path_to_os + "\"",
-                ".qcow2": " -hda \"" + path_to_os + "\""
-            }.get(os.path.splitext(path_to_os)[1].replace('"', '').lower(), None)
+                ".vhd": f" -drive format=raw,index=0,media=disk,file=\"{path_to_os}\"",
+                ".qcow2": f" -hda \"{path_to_os}\""
+            }.get(file_extension, None)
 
             if storage_rule is None:
                 raise Exception("Unknown OS storage type: " + path_to_os)

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -94,7 +94,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             storage_rule = {
                 ".vhd": " -drive format=raw,index=0,media=disk,file=\"" + path_to_os + "\"",
                 ".qcow2": " -hda \"" + path_to_os + "\""
-            }.get(os.path.splitext(path_to_os)[1], None)
+            }.get(os.path.splitext(path_to_os)[1].replace('"', ''), None)
 
             if storage_rule is None:
                 raise Exception("Unknown OS storage type: " + path_to_os)

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -94,7 +94,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             storage_rule = {
                 ".vhd": " -drive format=raw,index=0,media=disk,file=\"" + path_to_os + "\"",
                 ".qcow2": " -hda \"" + path_to_os + "\""
-            }.get(os.path.splitext(path_to_os)[1].replace('"', ''), None)
+            }.get(os.path.splitext(path_to_os)[1].replace('"', '').lower(), None)
 
             if storage_rule is None:
                 raise Exception("Unknown OS storage type: " + path_to_os)

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -90,8 +90,16 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         if path_to_os is not None:
             # Potentially dealing with big daddy, give it more juice...
             args += " -m 8192"
-            #args += " -hda \"" + path_to_os + "\""
-            args += " -drive format=raw,index=0,media=disk,file=\"" + path_to_os + "\""
+
+            storage_rule = {
+                ".vhd": " -drive format=raw,index=0,media=disk,file=\"" + path_to_os + "\"",
+                ".qcow2": " -hda \"" + path_to_os + "\""
+            }.get(os.path.splitext(path_to_os)[1], None)
+
+            if storage_rule is None:
+                raise Exception("Unknown OS storage type: " + path_to_os)
+            
+            args += storage_rule
         else:
             args += " -m 2048"
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This adds support for both VHD and QCOW2 images by using the extension to determine which storage rule should be used for qemu See [Issue 607](https://github.com/microsoft/mu_tiano_platforms/issues/607)

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_
 
- [X] Impacts functionality?
  - Adds back functionality for qcow2 images
- [ ] Impacts security?
  - N/A
- [ ] Breaking change?
  - N/A
- [ ] Includes tests?
  - N/A
- [ ] Includes documentation?
  - N/A
  
## How This Was Tested
This was used to run both a vhd image and a cow2 image, to confirm backward compatibility the resultant string was also compared

## Integration Instructions
N/A
