### PR TITLE
Use "usb-tablet" instead of "usb-mouse" as the pointer device

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -128,8 +128,8 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         # Add XHCI USB controller and mouse
         args += " -device qemu-xhci,id=usb"
-        args += " -device usb-mouse,id=input0,bus=usb.0,port=1"  # add a usb mouse
-        #args += " -device usb-kbd,id=input1,bus=usb.0,port=2"    # add a usb keyboar
+        args += " -device usb-tablet,id=input0,bus=usb.0,port=1"  # add a usb mouse
+        #args += " -device usb-kbd,id=input1,bus=usb.0,port=2"    # add a usb keyboard
 
         dfci_files = env.GetValue("DFCI_FILES")
         if dfci_files is not None:

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -69,8 +69,8 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         # Add XHCI USB controller and mouse
         args += " -device qemu-xhci,id=usb"
-        args += " -device usb-mouse,id=input0,bus=usb.0,port=1"  # add a usb mouse
-        args += " -device usb-kbd,id=input1,bus=usb.0,port=2"    # add a usb keyboar
+        args += " -device usb-tablet,id=input0,bus=usb.0,port=1"  # add a usb mouse
+        args += " -device usb-kbd,id=input1,bus=usb.0,port=2"    # add a usb keyboard
         args += " -smbios type=0,vendor=Palindrome,uefi=on"
         args += " -smbios type=1,manufacturer=Palindrome,product=MuQemuQ35,serial=42-42-42-42"
         args += f" -smbios type=3,manufacturer=Palindrome,version={version},serial=42-42-42-42,asset=Q35,sku=Q35"


### PR DESCRIPTION
## Description

`usb-tablet` and `usb-mouse` both override the default PS/2 emulation
when enabled. `usb-tablet` uses absolute coordinates and allows QEMU
to report the mouse position without grabbing the device.

It also tracks the mouse cursor more accurately.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

QEMU Windows guest on Windows and Linux host.

## Integration Instructions

N/A