### PR TITLE
QemuRunner: Use NVMe for OS boot

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -92,15 +92,16 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
             file_extension = Path(path_to_os).suffix.lower().replace('"', '')
 
-            storage_rule = {
-                ".vhd": f" -drive format=raw,index=0,media=disk,file=\"{path_to_os}\"",
-                ".qcow2": f" -hda \"{path_to_os}\""
+            storage_format = {
+                ".vhd": "raw",
+                ".qcow2": "qcow2"
             }.get(file_extension, None)
 
-            if storage_rule is None:
-                raise Exception("Unknown OS storage type: " + path_to_os)
+            if storage_format is None:
+                raise Exception(f"Unknown OS storage type: {path_to_os}")
 
-            args += storage_rule
+            args += f" -drive file=\"{path_to_os}\",format={storage_format},if=none,id=os_nvme"
+            args += " -device nvme,serial=nvme-1,drive=os_nvme"
         else:
             args += " -m 2048"
 


### PR DESCRIPTION
## Description

This section in the QEMU documentation provides an overview of block
device options:

https://www.qemu.org/docs/master/system/qemu-manpage.html#hxtool-1

This change uses an NVMe device for the OS boot drive to exercise
the NVMe driver stack during boot and better reflect more common
modern use cases.

Other block devices mapped are left unchanged as I did not see an
obvious reason to change those right now.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Build and boot to Windows with PATH_TO_OS set to a QCOW2 formatted image
- Convert the QCOW2 image to VHD and boot again to Windows with PATH_TO_OS set
- Verify the device is recognized as a NVMe device in UEFI shell
- Verify the OS disk drive is reported as NVMe in the OS
![image](https://github.com/microsoft/mu_tiano_platforms/assets/21320094/0782a8ed-df4c-401e-9653-0d3c1b3a5645)


## Integration Instructions

N/A - From a user perspective PATH_TO_OS works similar to before and
NVMe support is already present in the firmware.