### PR TITLE
Bump Common/MU to v2023020001.3.1 and Remove Paging Audit Test Exemption

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -393,7 +393,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         FEOL = FAILURE_EXEMPT_OMISSION_LENGTH
 
         if run_paging_audit:
-            self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"), "Q35", "X64")
+            self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"), "Q35")
 
         # Filter out tests that are exempt
         tests = list(filter(lambda file: file.name not in FET or not (now - FET.get(file.name)).total_seconds() < FEOL, test_list))

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -30,7 +30,6 @@ from io import StringIO
 # Declare test whose failure will not return a non-zero exit code
 FAILURE_EXEMPT_TESTS = {
     "VariablePolicyFuncTestApp.efi": datetime.datetime(2023, 7, 20, 0, 0, 0),
-    "DxePagingAuditTestApp.efi": datetime.datetime(2023, 7, 20, 0, 0, 0),
 }
 
 # Allow failure exempt tests to be ignored for 90 days
@@ -419,7 +418,7 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         FEOL = FAILURE_EXEMPT_OMISSION_LENGTH
 
         if run_paging_audit:
-            self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"), "SBSA", "AARCH64")
+            self.Helper.generate_paging_audit (virtual_drive, Path(drive_path).parent / "unit_test_results", self.env.GetValue("VERSION"), "SBSA")
 
         # Filter out tests that are exempt
         tests = list(filter(lambda file: file.name not in FET or not (now - FET.get(file.name)).total_seconds() < FEOL, test_list))

--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -442,9 +442,9 @@ class VirtualDriveManager(IUefiHelperPlugin):
         return failure_count
     
     @staticmethod
-    def generate_paging_audit(drive: VirtualDrive, report_output_dir: Path, version: str, platform: str, arch: str):
+    def generate_paging_audit(drive: VirtualDrive, report_output_dir: Path, version: str, platform: str):
         paging_audit_data_files = ["1G.dat", "2M.dat", "4K.dat", "PDE.dat", "MAT.dat",
-                                   "GuardPage.dat", "MemoryInfoDatabase.dat"]
+                                   "GuardPage.dat", "MemoryInfoDatabase.dat", "PlatformInfo.dat"]
         paging_audit_generator_path = os.path.join("Common", "MU", "UefiTestingPkg", "AuditTests",
                                                    "PagingAudit", "Windows", "PagingReportGenerator.py")
         report_output_dir.mkdir(exist_ok=True)
@@ -454,7 +454,7 @@ class VirtualDriveManager(IUefiHelperPlugin):
         output_debug = os.path.join(report_output_dir, "pagingauditdebug.txt")
         cmd = "python"
         args = f"{paging_audit_generator_path} -i {report_output_dir} -o {output_audit} \
--p {platform} -t DXE --debug -l {output_debug} -a {arch} --PlatformVersion {version}"
+-p {platform} --debug -l {output_debug} --PlatformVersion {version}"
         result = RunCmd(cmd, args)
         if result != 0:
             e = f"[{cmd} {args}] Result: {result}"


### PR DESCRIPTION
## Description

The most recent changes in mu_plus fix the paging audit test failures on SBSA. This PR pulls in the latest mu_plus, updates the paging audit calls to reflect the new command line interface, and removes the PagingAuditTestApp test failure exemption on SBSA.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested in the pipelines

## Integration Instructions

N/A
