### PR TITLE
QemuRunner: Prevent virtual drive unknown image format warning

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -167,7 +167,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -net none"
             # Mount disk with startup.nsh
             if os.path.isfile(VirtualDrive):
-                args += f" -hdd {VirtualDrive}"
+                args += f" -drive file={VirtualDrive},if=virtio"
             elif os.path.isdir(VirtualDrive):
                 args += f" -drive file=fat:rw:{VirtualDrive},format=raw,media=disk"
             else:

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -80,7 +80,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += f" -drive file=\"{path_to_os}\",format={storage_format},if=none,id=os_nvme"
             args += " -device nvme,serial=nvme-1,drive=os_nvme"
         elif os.path.isfile(VirtualDrive):
-            args += f" -hdd {VirtualDrive}"
+            args += f" -drive file={VirtualDrive},if=virtio"
         elif os.path.isdir(VirtualDrive):
             args += f" -drive file=fat:rw:{VirtualDrive},format=raw,media=disk"
         else:


### PR DESCRIPTION
## Description

The virtual drive image is passed with the following parameter:

  `-hdd <VirtualDrivePath>`

This results in the following warning:

```
WARNING: Image format was not specified for 'VirtualDrive.img' and
         probing guessed raw.

         Automatically detecting the format is dangerous for raw
         images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the
         restrictions.
```

This passes the image using `-drive` to resolve the warning.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- QemuQ35Pkg and QemuSbsaPkg build and run

## Integration Instructions

N/A