### PR TITLE
QemuQ35Pkg/SmmAccess: Add missing include guard

### DIFF
--- a/Platforms/QemuQ35Pkg/SmmAccess/SmramInternal.h
+++ b/Platforms/QemuQ35Pkg/SmmAccess/SmramInternal.h
@@ -8,6 +8,9 @@
 
 **/
 
+#ifndef SMM_ACCESS_SMRAM_INTERNAL_H_
+#define SMM_ACCESS_SMRAM_INTERNAL_H_
+
 #include <Pi/PiMultiPhase.h>
 
 //
@@ -102,3 +105,5 @@ SmramAccessGetCapabilities (
   IN OUT UINTN                 *SmramMapSize,
   IN OUT EFI_SMRAM_DESCRIPTOR  *SmramMap
   );
+
+#endif


### PR DESCRIPTION
## Description

All header files should have include guards.

See the following for more info:
https://codeql.github.com/codeql-query-help/cpp/cpp-missing-header-guard/

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- CI build
- Ran CodeQL with `cpp-missing-header-guard` enabled

## Integration Instructions

N/A