### PR TITLE
QemuQ35Pkg/PlatformBuild.py: Make workspace root stable

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -23,7 +23,7 @@ from typing import Tuple
 from pathlib import Path
 from io import StringIO
 
-WORKSPACE_ROOT = Path(__file__).parent.parent.parent.cwd()
+WORKSPACE_ROOT = str(Path(__file__).parent.parent.parent)
 
 # Declare test whose failure will not return a non-zero exit code
 FAILURE_EXEMPT_TESTS = {
@@ -75,7 +75,7 @@ class CommonPlatform():
         if codeql_enabled:
             codeql_filter_files = [str(n) for n in glob.glob(
                 os.path.join(WORKSPACE_ROOT,
-                                '**/CodeQlFilters.yml'), recursive=True)]
+                             '**/CodeQlFilters.yml'), recursive=True)]
             shell_environment.GetBuildVars().SetValue(
                 "STUART_CODEQL_FILTER_FILES",
                 ','.join(codeql_filter_files),
@@ -142,7 +142,7 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
 
     def GetWorkspaceRoot(self):
         ''' get WorkspacePath '''
-        return str(WORKSPACE_ROOT)
+        return WORKSPACE_ROOT
 
     def GetActiveScopes(self):
         ''' return tuple containing scopes that should be active for this process '''
@@ -211,7 +211,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
     def GetWorkspaceRoot(self):
         ''' get WorkspacePath '''
-        return str(WORKSPACE_ROOT)
+        return WORKSPACE_ROOT
 
     def GetPackagesPath(self):
         ''' Return a list of workspace relative paths that should be mapped as edk2 PackagesPath '''


### PR DESCRIPTION
## Description

The root is currently determined using `cwd()` which can cause the
root to be relative to the directory where the stuart command is
invoked from. It should always return the same absolute path so
`cwd()` is removed.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

QemuQ35Pkg build from the root directory and subdirectories.

## Integration Instructions

N/A