### PR TITLE
Fixing selfhosted agent on AARCH64 systems

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -16,8 +16,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: kuqin12/mu_devops
-      ref: fix_arm64
+      name: microsoft/mu_devops
+      ref: refs/tags/v6.4.1
 
 parameters:
 - name: do_ci_build

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -112,6 +112,7 @@ jobs:
       clean: true
     - ${{ parameters.extra_cargo_steps }}
     - template: Steps/RustCargoSteps.yml@mu_devops
-
+      parameters:
+        container_build: true
 - ${{ parameters.extra_jobs }}
 

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v6.4.1
+      ref: refs/tags/v6.5.1
 
 parameters:
 - name: do_ci_build

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -16,8 +16,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: microsoft/mu_devops
-      ref: refs/tags/v6.1.0
+      name: kuqin12/mu_devops
+      ref: fix_arm64
 
 parameters:
 - name: do_ci_build
@@ -81,10 +81,8 @@ jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
     linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:9ab29bc
-    ${{ if and(eq(parameters.rust_build, true), eq(parameters.pool_name, '')) }}:
+    ${{ if eq(parameters.rust_build, true) }}:
       linux_container_options: --security-opt seccomp=unconfined
-      extra_steps:
-      - template: Steps/RustSetupSteps.yml@mu_devops
     do_ci_build: ${{ parameters.do_ci_build }}
     do_ci_setup: ${{ parameters.do_ci_setup }}
     do_pr_eval: ${{ parameters.do_pr_eval }}
@@ -97,6 +95,7 @@ jobs:
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_build: ${{ parameters.container_build }}
+    rust_build: ${{ parameters.rust_build }}
 
 - ${{ if eq(parameters.rust_build, true) }}:
   - job: CargoCmds

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -16,8 +16,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: microsoft/mu_devops
-      ref: refs/tags/v6.1.0
+      name: kuqin12/mu_devops
+      ref: fix_arm64
 
 parameters:
 - name: do_ci_build

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -81,7 +81,7 @@ jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
     linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:9ab29bc
-    ${{ if eq(parameters.rust_build, true) }}:
+    ${{ if and(eq(parameters.rust_build, true), ne(parameters.pool_name, '')) }}:
       linux_container_options: --security-opt seccomp=unconfined
       extra_steps:
       - template: Steps/RustSetupSteps.yml@mu_devops

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -81,7 +81,7 @@ jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
     linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-22-build:9ab29bc
-    ${{ if and(eq(parameters.rust_build, true), ne(parameters.pool_name, '')) }}:
+    ${{ if and(eq(parameters.rust_build, true), eq(parameters.pool_name, '')) }}:
       linux_container_options: --security-opt seccomp=unconfined
       extra_steps:
       - template: Steps/RustSetupSteps.yml@mu_devops

--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -16,8 +16,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: kuqin12/mu_devops
-      ref: fix_arm64
+      name: microsoft/mu_devops
+      ref: refs/tags/v6.1.0
 
 parameters:
 - name: do_ci_build

--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -65,6 +65,8 @@ jobs:
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_ARM"
+        BuildExtraStep:
+          - script: echo No extra steps provided
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
@@ -80,6 +82,8 @@ jobs:
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_ARM"
+        BuildExtraStep:
+          - script: echo No extra steps provided
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
@@ -146,6 +150,8 @@ jobs:
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_AARCH64"
+        BuildExtraStep:
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
@@ -161,6 +167,8 @@ jobs:
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_AARCH64"
+        BuildExtraStep:
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true

--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -10,8 +10,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: kuqin12/mu_devops
-      ref: fix_arm64
+      name: microsoft/mu_devops
+      ref: refs/tags/v6.1.0
   containers:
     - container: linux-gcc
       image: ghcr.io/microsoft/mu_devops/ubuntu-22-test:latest
@@ -65,8 +65,6 @@ jobs:
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_ARM"
-        BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
@@ -82,8 +80,6 @@ jobs:
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_ARM"
-        BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true

--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -10,8 +10,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: microsoft/mu_devops
-      ref: main
+      name: kuqin12/mu_devops
+      ref: fix_arm64
   containers:
     - container: linux-gcc
       image: ghcr.io/microsoft/mu_devops/ubuntu-22-test:latest

--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -146,8 +146,6 @@ jobs:
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_AARCH64"
-        BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
@@ -163,8 +161,6 @@ jobs:
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_AARCH64"
-        BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true

--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v6.1.0
+      ref: main
   containers:
     - container: linux-gcc
       image: ghcr.io/microsoft/mu_devops/ubuntu-22-test:latest

--- a/.azurepipelines/Platform-Build-VS.yml
+++ b/.azurepipelines/Platform-Build-VS.yml
@@ -67,6 +67,8 @@ jobs:
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_ARM"
+        BuildExtraStep:
+          - script: echo No extra steps provided
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
@@ -82,6 +84,8 @@ jobs:
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_ARM"
+        BuildExtraStep:
+          - script: echo No extra steps provided
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true

--- a/.azurepipelines/Platform-Build-VS.yml
+++ b/.azurepipelines/Platform-Build-VS.yml
@@ -10,8 +10,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: microsoft/mu_devops
-      ref: main
+      name: kuqin12/mu_devops
+      ref: fix_arm64
 
 variables:
 - group: tool-chain-windows-visual-studio-latest

--- a/.azurepipelines/Platform-Build-VS.yml
+++ b/.azurepipelines/Platform-Build-VS.yml
@@ -10,8 +10,8 @@ resources:
     - repository: mu_devops
       type: github
       endpoint: microsoft
-      name: kuqin12/mu_devops
-      ref: fix_arm64
+      name: microsoft/mu_devops
+      ref: refs/tags/v6.1.0
 
 variables:
 - group: tool-chain-windows-visual-studio-latest
@@ -67,8 +67,6 @@ jobs:
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_ARM"
-        BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
@@ -84,8 +82,6 @@ jobs:
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_ARM"
-        BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: false
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true

--- a/.azurepipelines/Platform-Build-VS.yml
+++ b/.azurepipelines/Platform-Build-VS.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v6.1.0
+      ref: main
 
 variables:
 - group: tool-chain-windows-visual-studio-latest


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

There has been build failures observed on selfhosted pipelines running on AARCH64 systems. It was due to the rust setup we recently added.

The failure on the surface was because the build process will try to install x86_64 toolchain on AARCH64 systems. This change will remove the extra steps for selfhosted agent runs as those environments should be preset properly.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is tested on both internal and external pipelines.

## Integration Instructions

N/A
