### PR TITLE
Fixing multiple build instances usage on Linux environment

### DIFF
--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -166,7 +166,7 @@ class LinuxVirtualDrive(VirtualDrive):
         
         # Create an mtools config file to virtually map the image to a drive letter
         RunCmd("echo", "mtools_skip_check=1 > ~/.mtoolsrc")
-        RunCmd("echo", f"drive {self.drive_letter}: >> ~/.mtoolsrc")
+        RunCmd("echo", f"drive+ {self.drive_letter}: >> ~/.mtoolsrc")
         RunCmd("echo", f"\"  file=\\\"{self.drive_path}\\\" exclusive\" >> ~/.mtoolsrc")
 
     def add_file(self, filepath: PathLike):

--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -165,9 +165,8 @@ class LinuxVirtualDrive(VirtualDrive):
             raise RuntimeError(e)
         
         # Create an mtools config file to virtually map the image to a drive letter
-        RunCmd("echo", "mtools_skip_check=1 > ~/.mtoolsrc")
-        RunCmd("echo", f"drive+ {self.drive_letter}: >> ~/.mtoolsrc")
-        RunCmd("echo", f"\"  file=\\\"{self.drive_path}\\\" exclusive\" >> ~/.mtoolsrc")
+        RunCmd("export", "MTOOLS_SKIP_CHECK=1")
+        RunCmd("export", f"MTOOLSRC=\"drive+ {self.drive_letter}:  file=\\\"{self.drive_path}\\\" exclusive\"")
 
     def add_file(self, filepath: PathLike):
         """Adds a file to the virtual drive."""

--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -15,6 +15,7 @@ from os import PathLike
 from pathlib import Path
 
 from edk2toolext.environment.plugintypes.uefi_helper_plugin import IUefiHelperPlugin
+from edk2toolext.environment import shell_environment
 from edk2toollib.utility_functions import RunCmd
 from html import unescape
 
@@ -165,8 +166,14 @@ class LinuxVirtualDrive(VirtualDrive):
             raise RuntimeError(e)
         
         # Create an mtools config file to virtually map the image to a drive letter
-        RunCmd("export", "MTOOLS_SKIP_CHECK=1")
-        RunCmd("export", f"MTOOLSRC=\"drive+ {self.drive_letter}:  file=\\\"{self.drive_path}\\\" exclusive\"")
+        conf_path = os.path.join(os.path.dirname(self.drive_path), "mtool.conf")
+        if os.path.exists(conf_path):
+            # This should be repopulated per build
+            RunCmd("rm", conf_path)
+        RunCmd("echo", "mtools_skip_check=1 > ~/.mtoolsrc")
+        RunCmd("echo", f"drive+ {self.drive_letter}: >> {conf_path}")
+        RunCmd("echo", f"\"  file=\\\"{self.drive_path}\\\" exclusive\" >> {conf_path}")
+        shell_environment.GetEnvironment().set_shell_var ("MTOOLSRC", conf_path)
 
     def add_file(self, filepath: PathLike):
         """Adds a file to the virtual drive."""


### PR DESCRIPTION
## Description

Current script will try to update the mcopy configuration file. After QEMU run, the build script will then try to open the virtual disk indicated in this configuration. When there are multiple building instances on the same Linux system, we could end up with various conflicts, either opening up the incorrect image file, or opened up a file from other build jobs.

This change attempts to fix it by initiating a configuration file for each build for reference and update the environment variable to set up the configuration.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on both selfhost agents internal and here on the public pipeline builds.

## Integration Instructions

N/A.
