### PR TITLE
Docs/Common/Featues: Add Front Page Instructions

### DIFF
--- a/Platforms/Docs/Common/Features/feature_frontpage.md
+++ b/Platforms/Docs/Common/Features/feature_frontpage.md
@@ -1,5 +1,26 @@
 # Front Page
 
-Todo
+The Project Mu graphical front page provides access to system information, boot option configuration, and
+[DFCI](https://github.com/microsoft/mu_feature_dfci) configuration settings.
+
+For more information about front page, refer to its documentation -
+[OemPkg - Front Page](https://github.com/microsoft/mu_oem_sample/blob/HEAD/Docs/OemPkg.md).
 
 ![Front page in Q35](mu_frontpage.gif)
+
+## Entering Front Page
+
+Two build variables are available that influence how front page is built and loaded.
+
+1. `BLD_*_GUI_FRONT_PAGE=TRUE` - Builds the front page application shown here instead of alternative non-GUI
+   applications that act as the front page. The default value for this variable is `FALSE`, therefore it must be set
+   to `TRUE`.
+2. `BOOT_TO_FRONT_PAGE=TRUE` - Simulates pressing the Vol+ button which indicates that the boot should prioritize the
+   front page boot option. If this is not done, but (1) is set to `TRUE`, this front page can still be entered but it
+   is not loaded automatically. Instead, the boot will likely boot to the EFI shell and then exiting the shell (with
+   the `exit` command), will switch to this front page.
+
+   Once in front page, the boot option order can be configured as desired. This front page's boot option entry is named
+   "Mu UEFI UI Front Page".
+
+   The default value for this variable is `FALSE`.


### PR DESCRIPTION
## Description

Since there's a couple build variables that can influence which front
page is built and how it is loaded, this change updates the currently
empty front page feature document to include the relevant build
variable information.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI build including markdownlint.

## Integration Instructions

N/A