### PR TITLE
Add rust-ci scope to Qemu35Pkg and QemuSbsaPkg

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -46,7 +46,7 @@ class CommonPlatform():
     PackagesSupported = ("QemuQ35Pkg",)
     ArchSupported = ("IA32", "X64")
     TargetsSupported = ("DEBUG", "RELEASE", "NOOPT")
-    Scopes = ('qemu', 'qemuq35', 'edk2-build', 'cibuild', 'configdata')
+    Scopes = ('qemu', 'qemuq35', 'edk2-build', 'cibuild', 'configdata', 'rust-ci')
     PackagesPath = (
         "Platforms",
         "MU_BASECORE",
@@ -245,7 +245,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
         Args:
             loggerType (str): type of logger being logged to
-        
+
         Returns:
             (Logging.Level): The logging level
 

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -39,7 +39,7 @@ class CommonPlatform():
     PackagesSupported = ("QemuSbsaPkg",)
     ArchSupported = ("AARCH64",)
     TargetsSupported = ("DEBUG", "RELEASE", "NOOPT")
-    Scopes = ('qemu', 'qemusbsa', 'gcc_aarch64_linux', 'edk2-build', 'cibuild', 'configdata')
+    Scopes = ('qemu', 'qemusbsa', 'gcc_aarch64_linux', 'edk2-build', 'cibuild', 'configdata', 'rust-ci')
     WorkspaceRoot = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     PackagesPath = (
         "Platforms",
@@ -212,7 +212,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
         Args:
             loggerType (str): type of logger being logged to
-        
+
         Returns:
             (Logging.Level): The logging level
 


### PR DESCRIPTION
## Description

Add this scope so Rust related CI plugins run since the packages are
already building Rust code.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Verified CI builds with the scope set

## Integration Instructions

N/A - Affects plugins run in this repo