### PR TITLE
Bump MU_BASECORE from 2023020007.1.2 to 2023020007.1.3 [Rebase & FF]

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -104,6 +104,7 @@
   OemHookStatusCodeLib    |MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   PerformanceLib          |MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
   ConsoleMsgLib           |PcBdsPkg/Library/ConsoleMsgLibNull/ConsoleMsgLibNull.inf
+  PanicLib                |MdePkg/Library/BasePanicLibSerialPort/BasePanicLibSerialPort.inf
 !if $(SOURCE_DEBUG_ENABLE) == TRUE
   PeCoffExtraActionLib    |SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLibDebug.inf
   DebugCommunicationLib   |SourceLevelDebugPkg/Library/DebugCommunicationLibSerialPort/DebugCommunicationLibSerialPort.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -102,6 +102,7 @@
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicArmVirt.inf
   UefiDecompressLib|MdePkg/Library/BaseUefiDecompressLib/BaseUefiDecompressLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
+  PanicLib|MdePkg/Library/BasePanicLibSerialPort/BasePanicLibSerialPort.inf
 
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   HobLib|ArmVirtPkg/Library/ArmVirtDxeHobLib/ArmVirtDxeHobLib.inf


### PR DESCRIPTION
Bumps MU_BASECORE from `2023020007.1.2` to `2023020007.1.3`


Introduces 2 new commits in [MU_BASECORE](https://github.com/microsoft/mu_basecore.git).

<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/microsoft/mu_basecore/commit/1f32c267225e34873d69a89be2e5d7bec86fad7c">1f32c2</a> MdeModulePkg and UefiCpuPkg CodeQL Fixes (<a href="https://github.com/microsoft/mu_basecore/pull/561">#561</a>)</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/461a59c408ea925656e1b951acbebb41f8e89633">461a59</a> EsrtFmp CodeQL Fix (<a href="https://github.com/microsoft/mu_basecore/pull/598">#598</a>)</li>
</ul>
</details>

Signed-off-by: Project Mu Bot <mubot@microsoft.com>