### PR TITLE
QemuRunner.py: Allow a user specified QEMU path

### DIFF
--- a/Platforms/Docs/Common/building.md
+++ b/Platforms/Docs/Common/building.md
@@ -98,7 +98,8 @@ On most Linux distros this requires an extra step for mono and nuget support.
 
 ### Notes
 
-1. QEMU must be on your path. On Windows this is a manual process and not part of the QEMU installer.
+1. QEMU must be on your path or `QEMU_PATH` must be given. On Windows this is a manual process and not part of the
+   QEMU installer.
 2. QEMU output will be in Build directory.
 
 **NOTE:** Logging the execution output will be in the normal stuart log as well as to your console (if you have the
@@ -109,6 +110,8 @@ correct logging level set, by default it doesn't output to console).
 **SHUTDOWN_AFTER_RUN=TRUE** will output a *startup.nsh* file to the location mapped as fs0 with `reset -s` as
 the final line. This is used in CI in combination with the `--FlashOnly` feature to run QEMU to the UEFI shell
 and then execute the contents of *startup.nsh*.
+
+**QEMU_PATH** Can specify the path to a specific QEMU binary to use.
 
 **QEMU_HEADLESS=TRUE** Since CI servers run headless QEMU must be told to run with no display otherwise
 an error occurs. Locally you don't need to set this.

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -57,8 +57,8 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         OutputPath_FV = os.path.join(env.GetValue("BUILD_OUTPUT_BASE"), "FV")
         repo_version = env.GetValue("VERSION", "Unknown")
 
-        # Check if QEMU is on the path, if not find it
-        executable = "qemu-system-x86_64"
+        # Use a provided QEMU path. Default to the system path if not provided.
+        executable = env.GetValue("QEMU_PATH", "qemu-system-x86_64")
 
         # First query the version
         qemu_version = QemuRunner.QueryQemuVersion(executable)

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -56,8 +56,8 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         OutputPath_FV = os.path.join(env.GetValue("BUILD_OUTPUT_BASE"), "FV")
         repo_version = env.GetValue("VERSION", "Unknown")
 
-        # Check if QEMU is on the path, if not find it
-        executable = "qemu-system-aarch64"
+        # Use a provided QEMU path. Default to the system path if not provided.
+        executable = env.GetValue("QEMU_PATH", "qemu-system-aarch64")
 
         qemu_version = QemuRunner.QueryQemuVersion(executable)
 


### PR DESCRIPTION
## Description

On Linux, I build QEMU images with various features enabled. To more
easily enable users to use a custom QEMU image, this change
introduces a new variable `QEMU_PATH` that will override the default
executable used from the system path if provided.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Built packages with `QEMU_PATH` present and not present.

## Integration Instructions

N/A - Instructions for usage are in Platforms/Docs/Common/building.md