### PR TITLE
Bump Common/MU from 2023020003.1.0 to 2023020003.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "HiiKeyboardLayout"
+version = "0.1.0"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "r-efi",
+ "scroll",
+]
+
+[[package]]
 name = "RustAdvancedLoggerDxe"
 version = "0.1.0"
 dependencies = [
@@ -39,6 +49,7 @@ name = "UefiHidDxe"
 version = "0.1.0"
 dependencies = [
  "HidIo",
+ "HiiKeyboardLayout",
  "RustAdvancedLoggerDxe",
  "RustBootServicesAllocatorDxe",
  "hidparser",
@@ -68,6 +79,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "r-efi"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,7 +129,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,16 @@ members = [
 # Add packages that generate libraries here
 [workspace.dependencies]
 HidIo = {path = "Common/MU/HidPkg/Crates/HidIo"}
+HiiKeyboardLayout = {path = "Common/MU/HidPkg/Crates/HiiKeyboardLayout"}
 RustAdvancedLoggerDxe = {path = "Common/MU/AdvLoggerPkg/Crates/RustAdvancedLoggerDxe"}
 RustBootServicesAllocatorDxe = {path = "Common/MU/MsCorePkg/Crates/RustBootServicesAllocatorDxe"}
 
 hidparser = {git = "https://github.com/microsoft/mu_rust_hid.git", branch = "main"}
 memoffset = "0.9.0"
+num-traits = { version = "0.2", default-features = false}
+num-derive = { version = "0.4", default-features = false}
 r-efi = "4.3.0"
+scroll = { version = "0.11", default-features = false, features = ["derive"]}
 rustversion = "1.0.14"
 spin = "0.5.2"
 


### PR DESCRIPTION
Bumps Common/MU from `2023020003.1.0` to `2023020003.2.0`


Introduces 2 new commits in [Common/MU](https://github.com/microsoft/mu_plus.git).

<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/microsoft/mu_plus/commit/20cb1703e1f9214dd44925216a6bc5f9c09cfae0">20cb17</a> AdvLoggerPkg: Add PanicLib instance (<a href="https://github.com/microsoft/mu_plus/pull/348">#348</a>)</li>
<li><a href="https://github.com/microsoft/mu_plus/commit/22011420bde4e643ece940aeede894df021144b0">220114</a> Add HID Keyboard support to UefiHidDxe (<a href="https://github.com/microsoft/mu_plus/pull/347">#347</a>)</li>
</ul>
</details>

Signed-off-by: Project Mu Bot <mubot@microsoft.com>