### PR TITLE
Cargo.toml: Optimize dev profile binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,25 @@ memoffset = "0.9.0"
 r-efi = "4.3.0"
 rustversion = "1.0.14"
 spin = "0.5.2"
+
+# By default, the dev profile is used. The default build settings for the dev profile are documented here:
+# https://doc.rust-lang.org/cargo/reference/profiles.html#dev
+#
+# Unmodified dev profile settings result in extraordinarily large binaries relative to UEFI FW. This especially
+# impacts DEBUG builds which already have less optimized C code resulting in overall greater space occupation.
+# Without a change, the binaries are simply too large and will continue to push the limits of firmware volumes
+# (on a real system constrained by flash size) over time.
+#
+# Therefore, the below setting enables optimization level 3 (all optimizations) that is used by the release profile
+# by default. This greatly reduces the overall binary size. [profile.dev.package."*"] is specified to apply the
+# opt-level for all dependencies (but not a workspace member). This emphasizes debuggability of workspace code but
+# optimizes dependencies. An individual dependency can be overridden by specifying the named package instead of "*".
+# For example:
+#
+# [profile.dev.package.foo]
+# opt-level = 0
+#
+# That will likely allow the overall build to still fit in the FV but remove optimizations from an individual package
+# that needs to be debugged.
+[profile.dev.package."*"]
+opt-level = 3


### PR DESCRIPTION
## Description

By default, the dev profile is used. The default build settings for the dev profile are documented here:
https://doc.rust-lang.org/cargo/reference/profiles.html#dev

Unmodified dev profile settings result in extraordinarily large binaries relative to UEFI FW. This especially impacts `DEBUG` builds which already have less optimized C code resulting in overall greater space occupation.

Without a change, the binaries are simply too large and will continue to push the limits of firmware volumes (on a real system constrained by flash size) over time.

Therefore, the below setting enables optimization level `3` (all optimizations) that is used by the release profile by default. This greatly reduces the overall binary size. `[profile.dev.package."*"]` is specified to apply the opt-level for all dependencies (but not a workspace member). This emphasizes debuggability of workspace code but optimizes dependencies. An individual dependency can be overridden by specifying the named package instead of `"*"`. For example:

```ini
[profile.dev.package.foo]
opt-level = 0
```

That will likely allow the overall build to still fit in the FV, since other code is still optimized, but remove optimizations from an individual package that needs to be debugged.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Verified build size of several config combinations (including the chosen one).
  - ```
    [profile.dev]
    opt-level = 'z'
    ```
    - DXE FV: 11643648 (0xb1ab00) used (size opt of all packages)
  - ```
    [profile.dev.package."*"]
    opt-level = 'z'
    ```
    - DXE FV: 12365056 (0xbcad00) used (size opt of dependencies)
  - ```
    [profile.dev.package."*"]
    opt-level = 3
    ```
    - DXE FV: 12431104 (0xbdaf00) used (level 3 opt of dependencies)

## Integration Instructions

N/A - Affects packages built in this workspace