### PR TITLE
.git-blame-ignore-revs: Ignore Line Ending and Uncrustify only commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,19 @@
+###################################################
+# Line Ending Only Changes                        #
+###################################################
+# Fix line endings (LF to CRLF)
+c853b999de5d0bdece402c2cbd4782aad8002607
+# OvmfPkg: convert C files with LF line terminators to CRLF
+dde2662a0848293eed4fccc2d1ceaa429b1f7702
+# OvmfPkg/SerializeVariablesLib: convert line endings to uniform CRLF
+86cba94f94c7025dc6cbcf11ac0ca7d95d0c9f16
+# OvmfPkg/Sec/SecMain.c: Convert to CRLF (dos) text
+19ab6f660fb71168e67d770dca1166b4f85282e3
+
+###################################################
+# Code Formatting (Uncrustify) Only Changes       #
+###################################################
+# OvmfPkg: Uncrustify fixes
+1b090e756186838eed0c7477aa81c61315e90dad
+# OvmfPkg: Apply uncrustify changes
+b7893247c679c1bfb3a24f402358d47ecf9d7cb3


### PR DESCRIPTION
## Description

Adds commits that only applied Uncrustify formatting or converted
line endings to a .git-blame-ignore-revs file so they are ignored
by git blame. This is supported by GitHub:
https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/

This helps clean up git blame by filtering out these changes.

Note: This file needs to be updated on rebase branches. Processes
      like filter-branch can automatically update relevant SHAs.

---

Commits cover `OvmfPkg`. Although the package no longer exists, it is still in
the history of many files in derived packages.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- `git blame`

## Integration Instructions

N/A