### PR TITLE
Update pytool dependency

### DIFF
--- a/Platforms/QemuSbsaPkg/Test/PlatformTest.py
+++ b/Platforms/QemuSbsaPkg/Test/PlatformTest.py
@@ -10,7 +10,9 @@ from edk2toolext.environment.uefi_build import UefiBuilder
 from edk2toollib.utility_functions import RunCmd
 from edk2toolext.edk2_logging import SECTION, SUB_SECTION 
 from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
-from edk2toollib.database import Edk2DB
+from edk2toollib.database import Edk2DB, Environment, Inf, Source, InstancedInf
+from sqlalchemy import func, not_
+
 from pathlib import Path
 import logging
 import sys
@@ -27,39 +29,6 @@ PLATFORM_TEST_DSC = 'QemuSbsaPkg/Test/QemuSbsaPkgHostTest.dsc'
 PLATFORM_DSC = 'QemuSbsaPkg/QemuSbsaPkg.dsc'
 PLATFORMBUILD_DIR = str(Path(__file__).parent.parent)
 
-# The query to determine which INFs test source files used by QemuQ35Pkg/QemuQ35Pkg.dsc
-TEST_QUERY = """
-WITH host_test_files AS (
-    SELECT inf.path as 'inf', junction.key2 as 'source'
-    FROM
-        inf,
-        junction
-    WHERE
-        junction.table1 = 'inf'
-        AND junction.table2 = 'source'
-        AND inf.module_type = 'HOST_APPLICATION'
-        AND inf.path = junction.key1
-)
-SELECT DISTINCT host_test_files.inf
-FROM
-    instanced_inf_source_junction AS iisj
-JOIN host_test_files ON iisj.source = host_test_files.source
-WHERE
-    iisj.instanced_inf NOT LIKE '%UnitTestApp.inf'
-    AND iisj.env = ?;
-"""
-
-ID_QUERY_BY_PACKAGE = """
-SELECT environment.id
-FROM
-    environment
-    LEFT JOIN environment_values ON environment.id = environment_values.id
-WHERE
-    environment_values.key = 'ACTIVE_PLATFORM'
-    AND environment_values.value = ?
-ORDER BY environment.date DESC
-LIMIT 1;
-"""
 
 class TestSettingsManager(PlatformBuild.SettingsManager):
     pass
@@ -134,7 +103,7 @@ class TestManager(BuildSettingsManager, UefiBuilder):
         logging.info(f'Report Types: {",".join(reporttypes)}')
 
         coverage_file = Path(self.env.GetValue("BUILD_OUTPUT_BASE"), "_coverage.xml")
-        coverage_file = str(coverage_file.rename(coverage_file.parent / f'{PLATFORM_NAME}_coverage.xml'))
+        coverage_file = str(coverage_file.replace(coverage_file.parent / f'{PLATFORM_NAME}_coverage.xml'))
         if not self._reorganize_coverage_report(coverage_file):
             return -1
 
@@ -152,10 +121,26 @@ class TestManager(BuildSettingsManager, UefiBuilder):
         dscp.SetEdk2Path(self.edk2path).SetInputVars(self.env.GetAllBuildKeyValues() | self.env.GetAllNonBuildKeyValues())
         dscp.ParseFile(self.env.GetValue("ACTIVE_PLATFORM")) # The test DSC
 
-        with Edk2DB(db_path) as db:
+        with Edk2DB(db_path).session() as session:
             used_tests = set([component for component, _, _ in dscp.Components])
-            env_id = db.connection.execute(ID_QUERY_BY_PACKAGE, (PLATFORM_DSC,)).fetchone()[0]
-            must_use_tests = set([module for module, in db.connection.execute(TEST_QUERY, (env_id,)).fetchall()])
+            env_id = session.query(Environment).filter(Environment.values.any(key="ACTIVE_PLATFORM", value=PLATFORM_DSC)).order_by(Environment.date.desc()).first().id
+            host_tests = (
+                session
+                    .query(Inf.path, Source.path)
+                    .join(Inf.sources)
+                    .filter(Inf.module_type == "HOST_APPLICATION")
+                    .all()
+            )
+            source_query = (
+                session
+                    .query(Source.path)
+                    .join(InstancedInf.sources)
+                    .filter(InstancedInf.env == env_id)
+                    .filter(not_(func.lower(InstancedInf.name).like("%testapp%")))
+            )
+            used_source = set([source for source, in source_query.all()])
+            must_use_tests = set([module for module, source in host_tests if source in used_source])
+
             unused_tests = must_use_tests - used_tests
         
         if len(unused_tests) > 0:
@@ -245,7 +230,7 @@ class TestManager(BuildSettingsManager, UefiBuilder):
         return True
 
     def _verify_db_data(self, db_path: Path) -> bool:
-        with Edk2DB(db_path, self.edk2path) as db:
-            if db.connection.execute("SELECT COUNT(*) from instanced_inf WHERE ? LIKE '%' || dsc || '%'", (PLATFORM_DSC,)).fetchone()[0] == 0:
+        with Edk2DB(db_path).session() as session:
+            if len(session.query(Environment).filter(Environment.values.any(key="ACTIVE_PLATFORM", value=PLATFORM_DSC)).all()) == 0:
                 return False
             return True

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.19.9
-edk2-pytool-extensions==0.26.4
+edk2-pytool-library==0.20.0
+edk2-pytool-extensions==0.27.0
 xmlschema==3.0.1
 regex==2023.12.25
 pygount==1.6.1


### PR DESCRIPTION
## Description

Updates edk2-pytool-extensions to v0.27.0 and edk2-pytool-library to v0.20.0, which moves Edk2DB away from using sqlite3 directly, instead using a ORM to manage the database schema and querying functionlity. Applies the necessary changes to convert Edk2DB querying from raw SQL queries to sqlalchemy (ORM) queries.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

PlatformTest for QemuQ35Pkg and QemuSbsaPkg continues to work, and produces the same information.

## Integration Instructions

N/A