### PR TITLE
QemuQ35Pkg: Define SMM_CRYPTO_ARCH

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -50,6 +50,7 @@
   STANDALONEMM_CRYPTO_SERVICES = STANDARD
   PEI_CRYPTO_ARCH = IA32
   DXE_CRYPTO_ARCH = X64
+  SMM_CRYPTO_ARCH = NONE
   STANDALONEMM_CRYPTO_ARCH = X64
 
 ################################################################################


### PR DESCRIPTION
## Description

defines SMM_CRYPTO_ARCH in QemuQ35Pkg.dsc to resolve parser warnings regarding suspicious expressions that occur because $(SMM_CRYPTO_ARCH) is not replaced with a value (because a value is not defined).

Prints multiple of the following parser warning:

```cmd
INFO - Parser...
INFO - c:\src\mu_tiano_platforms\MU_BASECORE\CryptoPkg\Driver\Bin\Crypto.pcd.TINY_SHA.inc.dsc(112): warning: Suspicious expression: == Comparison between Operand of string type and Boolean/Number Type always return False.
INFO -     !if $(SMM_CRYPTO_ARCH) == X64
```

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Built with and without SMM_CRYPTO_ARCH being defined, and verified the parser warning was removed when it was defined.

## Integration Instructions

N/A
