### PR TITLE
[Rebase && FF] Bump MU_BASECORE from 2023110001.0.1 to 2023110001.0.2

### DIFF
--- a/Platforms/QemuQ35Pkg/Test/QemuQ35PkgHostTest.dsc
+++ b/Platforms/QemuQ35Pkg/Test/QemuQ35PkgHostTest.dsc
@@ -73,6 +73,7 @@
   HobLib|MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
   CpuPageTableLib|UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableLib.inf
+  NetLib|NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
 
 [LibraryClasses.X64]
   TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
@@ -215,6 +216,13 @@ SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/GoogleTest/ConfigKno
   <LibraryClasses>
     ConfigKnobShimLib|SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/ConfigKnobShimPeiLib.inf
     PeiServicesLib|MdePkg/Test/Mock/Library/GoogleTest/MockPeiServicesLib/MockPeiServicesLib.inf
+}
+
+NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6DxeGoogleTest.inf
+NetworkPkg/Ip6Dxe/GoogleTest/Ip6DxeGoogleTest.inf
+NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf {
+  <LibraryClasses>
+    UefiRuntimeServicesTableLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
 }
 
 [BuildOptions]

--- a/Platforms/QemuSbsaPkg/Test/QemuSbsaPkgHostTest.dsc
+++ b/Platforms/QemuSbsaPkg/Test/QemuSbsaPkgHostTest.dsc
@@ -73,6 +73,7 @@
   HobLib|MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.inf
   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
   CpuPageTableLib|UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableLib.inf
+  NetLib|NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
 
 [LibraryClasses.X64]
   TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
@@ -226,6 +227,13 @@ SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/GoogleTest/ConfigKno
   <LibraryClasses>
     ConfigKnobShimLib|SetupDataPkg/Library/ConfigKnobShimLib/ConfigKnobShimPeiLib/ConfigKnobShimPeiLib.inf
     PeiServicesLib|MdePkg/Test/Mock/Library/GoogleTest/MockPeiServicesLib/MockPeiServicesLib.inf
+}
+
+NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6DxeGoogleTest.inf
+NetworkPkg/Ip6Dxe/GoogleTest/Ip6DxeGoogleTest.inf
+NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf {
+  <LibraryClasses>
+    UefiRuntimeServicesTableLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
 }
 
 [BuildOptions]


### PR DESCRIPTION
Bumps MU_BASECORE from `2023110001.0.1` to `2023110001.0.2`


Introduces 1 new commits in [MU_BASECORE](https://github.com/microsoft/mu_basecore.git).

<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/microsoft/mu_basecore/commit/edb59034b832032c732b263a09635df1c29d78e7">edb590</a> [Release/202311] Cherry-Picks PixieFail vulnerability fixes for Bugs 1-7  (<a href="https://github.com/microsoft/mu_basecore/pull/738">#738</a>)</li>
</ul>
</details>

Signed-off-by: Project Mu Bot <mubot@microsoft.com>