### PR TITLE
QemuQ35Pkg: Update PlatformSecureLib to Qemu PlatformSecureLib

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -188,7 +188,7 @@
   SecurityManagementLib |MdeModulePkg/Library/DxeSecurityManagementLib/DxeSecurityManagementLib.inf
   SecurityLockAuditLib  |MdeModulePkg/Library/SecurityLockAuditDebugMessageLib/SecurityLockAuditDebugMessageLib.inf ##MU_CHANGE
   LockBoxLib            |QemuPkg/Library/LockBoxLib/LockBoxBaseLib.inf
-  PlatformSecureLib     |SecurityPkg/Library/PlatformSecureLibNull/PlatformSecureLibNull.inf
+  PlatformSecureLib     |QemuPkg/Library/PlatformSecureLib/PlatformSecureLib.inf
   PasswordStoreLib      |MsCorePkg/Library/PasswordStoreLibNull/PasswordStoreLibNull.inf
   PasswordPolicyLib     |OemPkg/Library/PasswordPolicyLib/PasswordPolicyLib.inf
   SecureBootVariableLib |SecurityPkg/Library/SecureBootVariableLib/SecureBootVariableLib.inf


### PR DESCRIPTION

## Description

Functionally, this just changes PlatformSecureLib to always return TRUE
So that UserPhysicalPresent(..) returns True

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [X] Impacts functionality?
  - **Functionality** - UserPhysicalPresent(..) always returns True
- [ ] Impacts security?
  - **Security** - No
- [ ] Breaking change?
  - **Breaking change** - No
- [ ] Includes tests?
  - **Tests** - No
- [ ] Includes documentation?
  - **Documentation** - No

## How This Was Tested

Tested locally to confirm UserPhysicalPresent(..) returns true when attempting to delete a secure boot authenticated variable.

## Integration Instructions

N/A