### PR TITLE
Set PcdFixedDebugPrintErrorLevel in QemuSbsaPkg to Improve Boot Time

### DIFF
--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -592,6 +592,7 @@
 
 !if $(TARGET) != RELEASE
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|$(DEBUG_PRINT_ERROR_LEVEL)
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel
 !endif
 
   #


### PR DESCRIPTION
## Description

There's a large slowdown during GCD sync when the syncing logic debug dumps the GCD map thousands of times. I updated the syncing logic to skip the dump process if the GCD debug verbosity level is not set. Checking the verbosity is done via a call to DebugPrintLevelEnabled() in DebugLib which checks the fixed debug print PCD.

This PR sets the FixedAtBuild PCD to be the same as the PatchableInModule PCD so the map dump function is skipped.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by booting SBSA and observing the improved boot time.

## Integration Instructions

N/A
