### PR TITLE
Add SSE4.2 to q35 QEMU runner CPU features

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -120,7 +120,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         logging.log(logging.INFO, "CPU model: " + cpu_model)
 
         #args += " -cpu qemu64,+rdrand,umip,+smep,+popcnt" # most compatible x64 CPU model + RDRAND + UMIP + SMEP +POPCNT support (not included by default)
-        cpu_arg = " -cpu " + cpu_model + ",rdrand=on,umip=on,smep=on,pdpe1gb=on,popcnt=on"
+        cpu_arg = " -cpu " + cpu_model + ",rdrand=on,umip=on,smep=on,pdpe1gb=on,popcnt=on,+sse4.2"
         args += cpu_arg
 
         if env.GetBuildValue ("QEMU_CORE_NUM") is not None:


### PR DESCRIPTION
## Description

The Instruction Set Extension, specifically SSE4.2, is standard and used by Windows. This adds it to the default QEMU configuration for Q35.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested local Windows boot.

## Integration Instructions

N/A
