### PR TITLE
Update Virtual Drive Manager File Collection and mu_plus Subrepo

### DIFF
--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -468,10 +468,7 @@ class VirtualDriveManager(IUefiHelperPlugin):
                                                    "PagingAudit", "Windows", "PagingReportGenerator.py")
         report_output_dir.mkdir(exist_ok=True)
         for file in paging_audit_data_files:
-            try:
-                drive.get_file(file, os.path.join(report_output_dir, file))
-            except RuntimeError as e:
-                logger.error(f"Failed to get {file} from drive.")
+            drive.get_file(file, os.path.join(report_output_dir, file))
         output_audit = os.path.join(report_output_dir, "pagingaudit.html")
         output_debug = os.path.join(report_output_dir, "pagingauditdebug.txt")
         cmd = "python"

--- a/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
+++ b/QemuPkg/Plugins/VirtualDriveManager/VirtualDriveManager.py
@@ -462,13 +462,16 @@ class VirtualDriveManager(IUefiHelperPlugin):
 
     @staticmethod
     def generate_paging_audit(drive: VirtualDrive, report_output_dir: Path, version: str, platform: str):
-        paging_audit_data_files = ["1G.dat", "2M.dat", "4K.dat", "PDE.dat", "MAT.dat",
+        paging_audit_data_files = ["1G.dat", "2M.dat", "4K.dat", "MAT.dat",
                                    "GuardPage.dat", "MemoryInfoDatabase.dat", "PlatformInfo.dat"]
         paging_audit_generator_path = os.path.join("Common", "MU", "UefiTestingPkg", "AuditTests",
                                                    "PagingAudit", "Windows", "PagingReportGenerator.py")
         report_output_dir.mkdir(exist_ok=True)
         for file in paging_audit_data_files:
-            drive.get_file(file, os.path.join(report_output_dir, file))
+            try:
+                drive.get_file(file, os.path.join(report_output_dir, file))
+            except RuntimeError as e:
+                logger.error(f"Failed to get {file} from drive.")
         output_audit = os.path.join(report_output_dir, "pagingaudit.html")
         output_debug = os.path.join(report_output_dir, "pagingauditdebug.txt")
         cmd = "python"


### PR DESCRIPTION
## Description

The PDE.dat file is no longer produced by the paging audit, so the get_file call will fail.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by running the paging audit on Q35 and SBSA

## Integration Instructions

N/A