### PR TITLE
[REBASE & FF] Wait for Serial Connection When SERIAL_PORT is Set in Q35 and SBSA

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -218,9 +218,10 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -gdb tcp::" + gdb_port
 
         # write ConOut messages to telnet localhost port
+        # Force QEMU to wait for serial connection before booting
         serial_port = env.GetValue("SERIAL_PORT")
         if serial_port != None:
-            args += " -serial tcp:127.0.0.1:" + serial_port + ",server,nowait"
+            args += " -serial tcp:127.0.0.1:" + serial_port + ",server"
 
         # Connect the debug monitor to a telnet localhost port
         monitor_port = env.GetValue("MONITOR_PORT")

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -131,9 +131,10 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -gdb tcp::" + gdb_port
 
         # write ConOut messages to telnet localhost port
+        # Force QEMU to wait for serial connection before booting
         serial_port = env.GetValue("SERIAL_PORT")
         if serial_port != None:
-            args += " -serial tcp:127.0.0.1:" + serial_port + ",server,nowait"
+            args += " -serial tcp:127.0.0.1:" + serial_port + ",server"
         else:
             # write messages to stdio
             args += " -serial stdio"


### PR DESCRIPTION
## Description

Removing 'nowait' from the QEMU command line will prompt QEMU to wait to execute the FW until a serial connection is made. This is valuable for debugging FW and avoids a developer needing to quickly enable a debugger.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Booted with GDB_SERVER and saw it wait.

## Integration Instructions

If GDB_SERVER is specified, connect the GDB server before QEMU execution continues.