### PR TITLE
Fix console after returning from QEMU

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -243,4 +243,12 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # Tested same FDs on QEMU 6 and 7, not observing the same.
             ret = 0
 
+        ## TODO: Recover the console. Remove this once QEMU fixes the issue: https://gitlab.com/qemu-project/qemu/-/issues/1674
+        if os.name == 'nt' and qemu_version[0] >= '8':
+            import win32console
+            h = win32console.GetStdHandle(win32console.STD_INPUT_HANDLE)
+            mode = h.GetConsoleMode()
+            # pywin32 does not have the constants for ENABLE_VIRTUAL_TERMINAL_INPUT
+            h.SetConsoleMode(mode & ~0x0200)
+
         return ret

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -251,6 +251,6 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             std_handle.SetConsoleMode(console_mode)
         elif os.name != 'nt':
             # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway
-            utility_functions.RunCmd ('stty', 'sane')
+            utility_functions.RunCmd('stty', 'sane', capture=False)
 
         return ret

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -246,8 +246,8 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # Tested same FDs on QEMU 6 and 7, not observing the same.
             ret = 0
 
-        ## TODO: Save the console mode. The original issue comes from: https://gitlab.com/qemu-project/qemu/-/issues/1674
         if os.name == 'nt' and qemu_version[0] >= '8':
+            # Restore the console mode for Windows on QEMU v8+.
             std_handle.SetConsoleMode(console_mode)
         elif os.name != 'nt':
             # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -143,11 +143,14 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         if monitor_port is not None:
             args += " -monitor tcp:127.0.0.1:" + monitor_port + ",server,nowait"
 
+        ## TODO: Save the console mode. The original issue comes from: https://gitlab.com/qemu-project/qemu/-/issues/1674
+        if os.name == 'nt' and qemu_version[0] >= '8':
+            import win32console
+            std_handle = win32console.GetStdHandle(win32console.STD_INPUT_HANDLE)
+            console_mode = std_handle.GetConsoleMode()
+
         # Run QEMU
         ret = utility_functions.RunCmd(executable, args)
-        if ret != 0 and os.name != 'nt':
-            # Linux version of QEMU will mess with the print if its run failed, this is to restore it
-            utility_functions.RunCmd ('stty', 'echo')
 
         ## TODO: restore the customized RunCmd once unit tests with asserts are figured out
         if ret == 0xc0000005:
@@ -158,5 +161,12 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # QEMU v4 will return segmentation fault when shutting down.
             # Tested same FDs on QEMU 6 and 7, not observing the same.
             ret = 0
+
+        if os.name == 'nt' and qemu_version[0] >= '8':
+            # Restore the console mode for Windows on QEMU v8+.
+            std_handle.SetConsoleMode(console_mode)
+        elif os.name != 'nt':
+            # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway
+            utility_functions.RunCmd('stty', 'sane', capture=False)
 
         return ret

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -17,3 +17,4 @@ edk2-pytool-extensions==0.27.3
 xmlschema==3.2.0
 regex==2023.12.25
 pygount==1.6.1
+pywin32==306; sys_platform == 'win32'


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The fix is enlightened by the original QEMU thread here: https://gitlab.com/qemu-project/qemu/-/issues/1674.

The change fixed the garbled command prompt after returning from QEMU v8+ on Windows platforms.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU v9.0.0-rc1 on Windows and confirmed it fixes the command prompt after returning from QEMU runner.

## Integration Instructions

N/A
