### PR TITLE
Added exception handling when `GetConsoleMode` API fails

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -231,8 +231,10 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         if os.name == 'nt' and qemu_version[0] >= '8':
             import win32console
             std_handle = win32console.GetStdHandle(win32console.STD_INPUT_HANDLE)
-            logging.critical(std_handle)
-            console_mode = std_handle.GetConsoleMode()
+            try:
+                console_mode = std_handle.GetConsoleMode()
+            except:
+                std_handle = None
 
         # Run QEMU
         ret = utility_functions.RunCmd(executable, args)
@@ -247,7 +249,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # Tested same FDs on QEMU 6 and 7, not observing the same.
             ret = 0
 
-        if os.name == 'nt' and qemu_version[0] >= '8':
+        if os.name == 'nt' and qemu_version[0] >= '8' and std_handle is not None:
             # Restore the console mode for Windows on QEMU v8+.
             std_handle.SetConsoleMode(console_mode)
         elif os.name != 'nt':

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -233,7 +233,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             std_handle = win32console.GetStdHandle(win32console.STD_INPUT_HANDLE)
             try:
                 console_mode = std_handle.GetConsoleMode()
-            except:
+            except Exception:
                 std_handle = None
 
         # Run QEMU

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -231,6 +231,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         if os.name == 'nt' and qemu_version[0] >= '8':
             import win32console
             std_handle = win32console.GetStdHandle(win32console.STD_INPUT_HANDLE)
+            logging.critical(std_handle)
             console_mode = std_handle.GetConsoleMode()
 
         # Run QEMU

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -149,7 +149,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             std_handle = win32console.GetStdHandle(win32console.STD_INPUT_HANDLE)
             try:
                 console_mode = std_handle.GetConsoleMode()
-            except:
+            except Exception:
                 std_handle = None
 
         # Run QEMU

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -147,7 +147,10 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         if os.name == 'nt' and qemu_version[0] >= '8':
             import win32console
             std_handle = win32console.GetStdHandle(win32console.STD_INPUT_HANDLE)
-            console_mode = std_handle.GetConsoleMode()
+            try:
+                console_mode = std_handle.GetConsoleMode()
+            except:
+                std_handle = None
 
         # Run QEMU
         ret = utility_functions.RunCmd(executable, args)
@@ -162,7 +165,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # Tested same FDs on QEMU 6 and 7, not observing the same.
             ret = 0
 
-        if os.name == 'nt' and qemu_version[0] >= '8':
+        if os.name == 'nt' and qemu_version[0] >= '8' and std_handle is not None:
             # Restore the console mode for Windows on QEMU v8+.
             std_handle.SetConsoleMode(console_mode)
         elif os.name != 'nt':


### PR DESCRIPTION
## Description

This change fixes a pipeline break after moving to QEMU v9.0.0 by adding a try-except routine to handle the case on the server builds.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change was tested locally and on the pipeline build.

## Integration Instructions

N/A