### PR TITLE
Bump Common/MU from 2023110000.0.5 to 2023110000.0.6

### DIFF
--- a/Platforms/QemuQ35Pkg/Test/QemuQ35PkgHostTest.dsc
+++ b/Platforms/QemuQ35Pkg/Test/QemuQ35PkgHostTest.dsc
@@ -35,7 +35,7 @@
 
 [LibraryClasses]
   MfciPolicyParsingLib|MfciPkg/Private/Library/MfciPolicyParsingLibNull/MfciPolicyParsingLibNull.inf
-  MfciDeviceIdSupportLib|MfciPkg/Library/MfciDeviceIdSupportLibNull/MfciDeviceIdSupportLibNull.inf
+  MfciDeviceIdSupportLib|MfciPkg/Library/MfciDeviceIdSupportLibSmbios/MfciDeviceIdSupportLibSmbios.inf
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf

--- a/Platforms/QemuSbsaPkg/Test/QemuSbsaPkgHostTest.dsc
+++ b/Platforms/QemuSbsaPkg/Test/QemuSbsaPkgHostTest.dsc
@@ -35,7 +35,7 @@
 
 [LibraryClasses]
   MfciPolicyParsingLib|MfciPkg/Private/Library/MfciPolicyParsingLibNull/MfciPolicyParsingLibNull.inf
-  MfciDeviceIdSupportLib|MfciPkg/Library/MfciDeviceIdSupportLibNull/MfciDeviceIdSupportLibNull.inf
+  MfciDeviceIdSupportLib|MfciPkg/Library/MfciDeviceIdSupportLibSmbios/MfciDeviceIdSupportLibSmbios.inf
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf


### PR DESCRIPTION
Bumps Common/MU from `2023110000.0.5` to `2023110000.0.6`


Introduces 3 new commits in [Common/MU](https://github.com/microsoft/mu_plus.git).

<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/microsoft/mu_plus/commit/cd7ce3ed8ae3ab38cdff67df6b8379a343347d52">cd7ce3</a> Relax report length requirements (<a href="https://github.com/microsoft/mu_plus/pull/455">#455</a>)</li>
<li><a href="https://github.com/microsoft/mu_plus/commit/e6308e0591505cacf9a142d4f091fd863f9f2fc8">e6308e</a> GitHub Action: Bump robinraju/release-downloader from 1.9 to 1.10 (<a href="https://github.com/microsoft/mu_plus/pull/472">#472</a>)</li>
<li><a href="https://github.com/microsoft/mu_plus/commit/da051c707f056617f8e10bf9f3cc5071bc504d83">da051c</a> Moving the global variable from header file into library instances (<a href="https://github.com/microsoft/mu_plus/pull/473">#473</a>)</li>
</ul>
</details>

Signed-off-by: Project Mu Bot <mubot@microsoft.com>