### PR TITLE
Add NETWORK_ENABLE option

### DIFF
--- a/Platforms/Docs/Common/building.md
+++ b/Platforms/Docs/Common/building.md
@@ -120,6 +120,9 @@ an error occurs. Locally you don't need to set this.
 
 **SERIAL_PORT=\<Serial Port\>** Enables the specified serial port to be used as console.
 
+**ENABLE_NETWORK=TRUE** will enable networking (currently supported on the QEMU Q35 platform). If `DFCI_VAR_STORE` is
+set, networking will also be enabled with TCP ports 8270 and 8271 forwarded for the robot framework.
+
 ### Passing Build Defines
 
 To pass build defines through *stuart_build*, prepend `BLD_*_` to the define name and pass it on the


### PR DESCRIPTION
## Description

Simplifies network enabling by using a dedicated flag for enabling.

Preserves existing behavior where networking is disabled by default.

Networking was hardcoded to off in the QemuSbsaPkg runner, that is
not modified in this change.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Run without flag set and verify networking is disabled.
- Run with flag and verify networking is enabled.

## Integration Instructions

N/A