### PR TITLE
Update Platform CI for -a flag removal

### DIFF
--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -31,7 +31,6 @@ jobs:
       QemuQ35_DEBUG:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
@@ -46,7 +45,6 @@ jobs:
       QemuQ35_RELEASE:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
@@ -61,7 +59,6 @@ jobs:
       QemuQ35_DEBUG_ARM:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_ARM"
@@ -78,7 +75,6 @@ jobs:
       QemuQ35_RELEASE_ARM:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_ARM"
@@ -95,7 +91,6 @@ jobs:
       QemuQ35_NO_SMM_RELEASE:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: "BLD_*_SMM_ENABLED=FALSE"
         BuildTarget: "RELEASE"
         BuildExtraTag: "NO_SMM"
@@ -110,7 +105,6 @@ jobs:
       QemuSbsa_DEBUG:
         BuildPackage: QemuSbsaPkg
         BuildFile: "Platforms/QemuSbsaPkg/PlatformBuild.py"
-        BuildArch: AARCH64
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
@@ -128,7 +122,6 @@ jobs:
       QemuSbsa_RELEASE:
         BuildPackage: QemuSbsaPkg
         BuildFile: "Platforms/QemuSbsaPkg/PlatformBuild.py"
-        BuildArch: AARCH64
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
@@ -146,7 +139,6 @@ jobs:
       QemuSbsa_DEBUG_ARM:
         BuildPackage: QemuSbsaPkg
         BuildFile: "Platforms/QemuSbsaPkg/PlatformBuild.py"
-        BuildArch: AARCH64
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_AARCH64"
@@ -163,7 +155,6 @@ jobs:
       QemuSbsa_RELEASE_ARM:
         BuildPackage: QemuSbsaPkg
         BuildFile: "Platforms/QemuSbsaPkg/PlatformBuild.py"
-        BuildArch: AARCH64
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_AARCH64"

--- a/.azurepipelines/Platform-Build-Job.yml
+++ b/.azurepipelines/Platform-Build-Job.yml
@@ -43,7 +43,6 @@ parameters:
   ## Build matrix to be supplied by both VS and GCC builds. The accepted parameters are listed below:
   # BuildPackage:         Packages to be built, i.e., QemuQ35Pkg
   # BuildFile:            Build script for building platform firmware, i.e., "Platforms/QemuQ35Pkg/PlatformBuild.py"
-  # BuildArch:            Architectures to be supported by platform firmware, i.e., IA32,X64
   # BuildFlags:           Additional build flags, set to empty string if none
   # BuildTarget:          Build targets to be used for platform firmware, i.e., "DEBUG"
   # BuildExtraTag:        Extra tags to be used as artifact identifier, this is especially useful when building the same packages with the tool chain and target
@@ -95,7 +94,6 @@ jobs:
           tool_chain_tag: $(tool_chain_tag)
           build_pkg: ${{ item.Value.BuildPackage }}
           build_target: ${{ item.Value.BuildTarget }}
-          build_arch: ${{ item.Value.BuildArch }}
           build_file: ${{ item.Value.BuildFile }}
           build_flags: ${{ item.Value.BuildFlags }}
           run_flags: ${{ item.Value.RunFlags }}
@@ -106,7 +104,7 @@ jobs:
           artifacts_binary: ${{ item.Value.BuildArtifactsBinary }}
           ${{ if or(eq(item.Value.Run, true), eq(parameters.os_type, 'Linux'), EndsWith(item.Key, 'CODE_COVERAGE')) }}:
             artifacts_other: ${{ item.Value.BuildArtifactsOther }}
-      
+
       - ${{ if EndsWith(item.Key, 'CODE_COVERAGE') }}:
         - template: Steps/UploadCodeCoverage.yml@mu_devops
           parameters:
@@ -151,7 +149,7 @@ jobs:
       - task: CmdLine@2
         displayName: Update
         inputs:
-          script: stuart_update -c ${{ item.Value.BuildFile }} TOOL_CHAIN_TAG=$(tool_chain_tag) -t ${{ item.Value.BuildTarget }} -a ${{ item.Value.BuildArch }} ${{ item.Value.BuildFlags }}
+          script: stuart_update -c ${{ item.Value.BuildFile }} TOOL_CHAIN_TAG=$(tool_chain_tag) -t ${{ item.Value.BuildTarget }} ${{ item.Value.BuildFlags }}
         condition: and(gt(variables.pkg_count, 0), succeeded())
 
       # Potential Extra steps
@@ -179,7 +177,7 @@ jobs:
       - task: CmdLine@2
         displayName: Run to Shell
         inputs:
-          script: stuart_build -c ${{ item.Value.BuildFile }} TOOL_CHAIN_TAG=$(tool_chain_tag) TARGET=${{ item.Value.BuildTarget }} -a ${{ item.Value.BuildArch }} ${{ item.Value.BuildFlags }} ${{ item.Value.RunFlags }} --FlashOnly
+          script: stuart_build -c ${{ item.Value.BuildFile }} TOOL_CHAIN_TAG=$(tool_chain_tag) TARGET=${{ item.Value.BuildTarget }} ${{ item.Value.BuildFlags }} ${{ item.Value.RunFlags }} --FlashOnly
         condition: and(gt(variables.pkg_count, 0), succeeded())
         timeoutInMinutes: ${{ parameters.run_timeout }}
 

--- a/.azurepipelines/Platform-Build-VS.yml
+++ b/.azurepipelines/Platform-Build-VS.yml
@@ -28,7 +28,6 @@ jobs:
       QemuQ35_DEBUG:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
@@ -43,7 +42,6 @@ jobs:
       QemuQ35_RELEASE:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
@@ -58,7 +56,6 @@ jobs:
       QemuQ35_DEBUG_ARM:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "DEBUG"
         BuildExtraTag: "ON_ARM"
@@ -75,7 +72,6 @@ jobs:
       QemuQ35_RELEASE_ARM:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: ""
         BuildTarget: "RELEASE"
         BuildExtraTag: "ON_ARM"
@@ -92,7 +88,6 @@ jobs:
       QemuQ35_NO_SMM_RELEASE:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
-        BuildArch: IA32,X64
         BuildFlags: "BLD_*_SMM_ENABLED=FALSE"
         BuildTarget: "RELEASE"
         BuildExtraTag: "NO_SMM"
@@ -107,7 +102,6 @@ jobs:
       QemuQ35_CODE_COVERAGE:
         BuildPackage: QemuQ35Pkg
         BuildFile: "Platforms/QemuQ35Pkg/Test/PlatformTest.py"
-        BuildArch: "X64"
         BuildFlags: "CODE_COVERAGE=TRUE CC_FULL=TRUE CC_FLATTEN=TRUE REPORTTYPES=Cobertura,HtmlSummary,JsonSummary"
         BuildTarget: "NOOPT"
         BuildExtraTag: "UNIT_TESTS"
@@ -116,11 +110,10 @@ jobs:
             displayName: Install Report Generator
         BuildArtifactsOther: "**/Coverage/**"
         Run: false
-      
+
       QemuSbsa_CODE_COVERAGE:
         BuildPackage: QemuSbsaPkg
         BuildFile: "Platforms/QemuSbsaPkg/Test/PlatformTest.py"
-        BuildArch: "AARCH64"
         BuildFlags: "CODE_COVERAGE=TRUE CC_FULL=TRUE CC_FLATTEN=TRUE REPORTTYPES=Cobertura,HtmlSummary,JsonSummary"
         BuildTarget: "NOOPT"
         BuildExtraTag: "UNIT_TESTS"

--- a/.github/workflows/codeql-platform.yml
+++ b/.github/workflows/codeql-platform.yml
@@ -125,7 +125,6 @@ jobs:
       matrix:
         build_file: ${{ fromJson(needs.gather_build_files.outputs.platform_build_files) }}
         include:
-          - archs: IA32,X64
           - tool_chain_tag: VS2022
 
     steps:
@@ -288,7 +287,7 @@ jobs:
       if: steps.get_platform_info.outputs.setup_supported == 'true'
       shell: pwsh
       working-directory: "Z:"
-      run: stuart_setup -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
+      run: stuart_setup -c ${{ matrix.build_file }} -t DEBUG TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Setup Log As An Artifact
       uses: actions/upload-artifact@v4
@@ -304,7 +303,7 @@ jobs:
       if: steps.get_platform_info.outputs.ci_setup_supported == 'true'
       shell: pwsh
       working-directory: "Z:"
-      run: stuart_ci_setup -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
+      run: stuart_ci_setup -c ${{ matrix.build_file }} -t DEBUG TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload CI Setup Log As An Artifact
       uses: actions/upload-artifact@v4
@@ -319,7 +318,7 @@ jobs:
     - name: Update
       shell: pwsh
       working-directory: "Z:"
-      run: stuart_update -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
+      run: stuart_update -c ${{ matrix.build_file }} -t DEBUG TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Update Log As An Artifact
       uses: actions/upload-artifact@v4
@@ -397,7 +396,7 @@ jobs:
       if: steps.codeqlcli_cache.outputs.cache-hit != 'true'
       shell: pwsh
       working-directory: "Z:"
-      run: stuart_update -c ${{ matrix.build_file }} -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
+      run: stuart_update -c ${{ matrix.build_file }} -t DEBUG TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 
     - name: Find pytool Plugin Directory
       id: find_pytool_dir

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -197,14 +197,6 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
     def AddCommandLineOptions(self, parserObj):
         ''' Add command line options to the argparser '''
-
-        # In an effort to support common server based builds this parameter is added.  It is
-        # checked for correctness but is never uses as this platform only supports a single set of
-        # architectures.
-        parserObj.add_argument('-a', "--arch", dest="build_arch", type=str, default="IA32,X64",
-            help="Optional - CSV of architecture to build.  IA32,X64 will use IA32 for PEI and "
-            "X64 for DXE and is the only valid option for this platform.")
-
         CommonPlatform.add_common_command_line_options(parserObj)
 
     def RetrieveCommandLineOptions(self, args):

--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -201,9 +201,6 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
     def RetrieveCommandLineOptions(self, args):
         '''  Retrieve command line options from the argparser '''
-        if args.build_arch.upper() != "IA32,X64":
-            raise Exception("Invalid Arch Specified.  Please see comments in PlatformBuild.py::PlatformBuilder::AddCommandLineOptions")
-
         self.codeql = CommonPlatform.is_codeql_enabled(args)
 
     def GetWorkspaceRoot(self):

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -167,11 +167,6 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
         return super().CleanTree(RemoveConfTemplateFilesToo)
 
-    def RetrieveCommandLineOptions(self, args):
-        '''  Retrieve command line options from the argparser '''
-        if args.build_arch.upper() != "AARCH64":
-            raise Exception("Invalid Arch Specified.  Please see comments in PlatformBuild.py::PlatformBuilder::AddCommandLineOptions")
-
     def GetWorkspaceRoot(self):
         ''' get WorkspacePath '''
         return CommonPlatform.WorkspaceRoot

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -167,16 +167,6 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
         return super().CleanTree(RemoveConfTemplateFilesToo)
 
-    def AddCommandLineOptions(self, parserObj):
-        ''' Add command line options to the argparser '''
-
-        # In an effort to support common server based builds this parameter is added.  It is
-        # checked for correctness but is never uses as this platform only supports a single set of
-        # architectures.
-        parserObj.add_argument('-a', "--arch", dest="build_arch", type=str, default="AARCH64",
-            help="Optional - CSV of architecture to build.  AARCH64 is used for PEI and "
-            "DXE and is the only valid option for this platform.")
-
     def RetrieveCommandLineOptions(self, args):
         '''  Retrieve command line options from the argparser '''
         if args.build_arch.upper() != "AARCH64":


### PR DESCRIPTION
## Description

Passes the architecture for platform builds through the build flags.

For compatibility with the v10.0.0 Mu DevOps release: https://github.com/microsoft/mu_devops/releases/tag/v10.0.0

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Pipeline build

## Integration Instructions

- N/A