### PR TITLE
pip: bump edk2-pytool-extensions and edk2-pytool-library

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.21.9
-edk2-pytool-extensions==0.27.10
+edk2-pytool-library==0.21.10
+edk2-pytool-extensions==0.27.11
 xmlschema==3.3.2
 regex==2024.7.24
 pygount==1.8.0


### PR DESCRIPTION

## Description

edk2-pytool-extensions from 0.27.10 to 0.27.11 
edk2-pytool-library from 0.21.9 to 0.21.10

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
N/A

## Integration Instructions
N/A