### PR TITLE
Set workspace resolver to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 # Add packages that generate binaries here
 members = [


### PR DESCRIPTION
## Description
Add an explicit set for resolver to use version 2. This is required for virtual workspaces as the rust edition cannot be inferred by the compiler.

For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
I validated that cargo make build, test, and coverage did not change.

## Integration Instructions
N/A
