### PR TITLE
QemuQ35Pkg.dsc: Apply XenHypercallLib to valid archs

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -220,7 +220,6 @@
   UnitTestResultReportLib |XmlSupportPkg/Library/UnitTestResultReportJUnitFormatLib/UnitTestResultReportLib.inf
 
   # Xen Libraries
-  XenHypercallLib |QemuQ35Pkg/Library/XenHypercallLib/XenHypercallLib.inf
   XenPlatformLib  |QemuPkg/Library/XenPlatformLib/XenPlatformLib.inf
 
   # Crypto Libraries
@@ -310,13 +309,16 @@
 
   AmdSvsmLib|UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.inf
 
-[LibraryClasses]
   # Platform Runtime Mechanism (PRM) libraries
   PrmContextBufferLib|PrmPkg/Library/DxePrmContextBufferLib/DxePrmContextBufferLib.inf
   PrmModuleDiscoveryLib|PrmPkg/Library/DxePrmModuleDiscoveryLib/DxePrmModuleDiscoveryLib.inf
   PrmPeCoffLib|PrmPkg/Library/DxePrmPeCoffLib/DxePrmPeCoffLib.inf
 
   StackCheckFailureHookLib|MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
+
+[LibraryClasses.IA32, LibraryClasses.X64]
+  XenHypercallLib|QemuQ35Pkg/Library/XenHypercallLib/XenHypercallLib.inf
+
 [LibraryClasses.common.PEI_CORE]
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
 


### PR DESCRIPTION
## Description

The XenHypercallLib instance in QemuQ35Pkg has the following LIBRARY_CLASS value in its [DEFINES] section:

```
  [Defines.IA32, Defines.X64]
    LIBRARY_CLASS                  = XenHypercallLib|...

  [Defines.ARM, Defines.AARCH64]
    LIBRARY_CLASS                  = XenHypercallLib
```

However, the library instance is specified in QemuQ35Pkg.dsc against the "Common" architecture as it is placed in the `[LibraryClasses]` section.

This raises the following warning during build:

```
  INFO - QemuQ35Pkg.dsc(...): warning:
    Platforms\QemuQ35Pkg\Library\XenHypercallLib\XenHypercallLib.inf
    does not support LIBRARY_CLASS XenHypercallLib
```

This is printed from the `_ValidateLibraryClass()` function in `BaseTools/Source/Python/Workspace/DscBuildData.py` because the library class is bound by architecture in the INF file so it does *not* support the "Common" architecture.

This change maps the library instance to the XenHypercallLib class per the defined architectures (`IA32` and `X64`) in QemuQ35Pkg.dsc.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `QemuQ35Pkg` before and after the change

## Integration Instructions

- N/A