### PR TITLE
QemuSbsaPkg: QemuRunner: Don't Expose Default Serial Port

### DIFF
--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -132,7 +132,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -gdb tcp::" + gdb_port
 
         # write ConOut messages to telnet localhost port
-        serial_port = env.GetValue("SERIAL_PORT", "50001")
+        serial_port = env.GetValue("SERIAL_PORT")
         if serial_port != None:
             args += " -serial tcp:127.0.0.1:" + serial_port + ",server,nowait"
         else:


### PR DESCRIPTION
## Description

This was PR feedback that was missed. SBSA only has a single serial port, so if we put out one by default, it will not print to stdio and we will miss the logs.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
