### PR TITLE
Bugfix: Do not enable SERIAL_PORT by default in SBSA

### DIFF
--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -132,7 +132,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -gdb tcp::" + gdb_port
 
         # write ConOut messages to telnet localhost port
-        serial_port = env.GetValue("SERIAL_PORT", "50001")
+        serial_port = env.GetValue("SERIAL_PORT")
         if serial_port != None:
             args += " -serial tcp:127.0.0.1:" + serial_port + ",server,nowait"
         else:


### PR DESCRIPTION
## Description

Bug fix for SERIAL_PORT being enabled by default in QemuRunner.py for SBSA.
On SBSA, the serial port should not be set by default, as it will prevent writing to stdout, making it hard to tell progress.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested locally in mu_tiano_platforms

## Integration Instructions

N/A
