### PR TITLE
FF-A SP and Service Changes (Notification, TPM, Test):

### DIFF
--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -398,7 +398,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
                         "file": os.path.join(os.path.dirname(__file__), "fdts/qemu_sbsa_example_config.dts"),
                         "offset": "0x1000"
                     },
-                    "uuid": "8064A10B-9A26-4DF8-9629-024B64058B4F",
+                    "uuid": "b8bcbd0c-8e8f-4ebe-99eb-3cbbdd0cd412",
                     "owner": "Plat"
                 }
             }

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -451,7 +451,7 @@
   RngLib                     |MdePkg/Library/PeiRngLib/PeiRngLib.inf
 
 !if $(TPM2_ENABLE) == TRUE
-  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+  Tpm2DeviceLib|ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
 !endif
 
 [LibraryClasses.common.DXE_CORE]
@@ -473,7 +473,7 @@
   PolicyLib|PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
 
 !if $(TPM2_ENABLE) == TRUE
-  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf
+  Tpm2DeviceLib|ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
 !endif
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
@@ -490,6 +490,7 @@
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
   ArmMmuLib|ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.inf
   StandaloneMmCoreEntryPoint|ArmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
@@ -908,7 +909,7 @@
   #
   # TPM2 support
   #
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0x60120000
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0x10000010000
 !if $(TPM2_ENABLE) == TRUE
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0
@@ -1242,8 +1243,6 @@
   SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf {
     <LibraryClasses>
       HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
-      Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
-      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
       NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf

--- a/Platforms/QemuSbsaPkg/fdts/qemu_sbsa_example_config.dts
+++ b/Platforms/QemuSbsaPkg/fdts/qemu_sbsa_example_config.dts
@@ -27,10 +27,10 @@
 
 	description = "Example Services";
 	ffa-version = <0x00010002>; /* 31:16 - Major, 15:0 - Minor */
-	uuid = <0x7036A3DB 0xBA3B44E5 0xB359E25E 0x5D904387>, <0x5B9ECC17 0x44D0447C 0xB49568BB 0x6A970764>;
+	uuid = <0xb510b3a3 0x59f64054 0xba7aff2e 0xb1eac765>, <0x17b862a4 0x18064faf 0x86b3089a 0x58353861>, <0xe0fad9b3 0x7f5c42c5 0xb2eeb7a8 0x2313cdb2>;
 	id = <0x8002>;
 	execution-ctx-count = <1>;
-	exception-level = <MODE_SEL0>; /* SEL0*/
+	exception-level = <MODE_SEL1>; /* SEL1*/
 	execution-state = <0>; /* AArch64*/
 	load-address = <0x0 0x20400000>;
 	entrypoint-offset = <0x10000>;
@@ -63,6 +63,20 @@
 		secure_uart {
 			base-address = <0x0 0x60030000>;
 			pages-count = <0x1>;
+			attributes = <SECURE_RW>;
+		};
+
+		internl_tpm_crb {
+			description = "internal tpm crb";
+			base-address = <0x00000100 0x00010000>;
+			pages-count = <0x10>;
+			attributes = <SECURE_RW>;
+		};
+
+		external_tpm_crb {
+			description = "external tpm crb";
+			base-address = <0x00000000 0x60120000>;
+			pages-count = <0x10>;
 			attributes = <SECURE_RW>;
 		};
 	};


### PR DESCRIPTION
## Description

Updated the mu_tiano_platforms build (ffa_enablement) to work with the latest ms-services SP including: Notification, Test, and TPM. PlatformBuild.py currently points to a hard coded SP binary but will be updated when we port the SP and services to UEFI style. Updated the TestApp to test all services.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Functionality tested with FfaPartitionTestApp and running with TPM enabled

## Integration Instructions

N/A