### PR TITLE
Fix memory leak and also detect failed memory allocation

### DIFF
--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -66,8 +66,9 @@ ApplyGfxConfigToPolicy (
 
   if (GfxSiliconPolicy == NULL) {
     DEBUG ((DEBUG_ERROR, "Failed to allocate Policy structure\n"));
+    Status = EFI_OUT_OF_RESOURCES;
     goto Exit;
-  }  // Mu
+  }  
  
   // We only translate the GFX ports #0 exposed to platform from conf data
   GfxSiliconPolicy[0].Power_State_Port = GfxEnablePort0;
@@ -76,11 +77,13 @@ ApplyGfxConfigToPolicy (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to update GFX policy per configuration data - %r!!!\n", __func__, Status));
-    ASSERT (FALSE);
-    FreePool (GfxSiliconPolicy);   //Mu
-    goto Exit;
+    ASSERT_EFI_ERROR (Status);
   }
-  FreePool (GfxSiliconPolicy);   //Mu
+
 Exit:
+  if (GfxSiliconPolicy != NULL) {
+    FreePool (GfxSiliconPolicy);   
+  }
+
   return Status;
 }

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -68,8 +68,8 @@ ApplyGfxConfigToPolicy (
     DEBUG ((DEBUG_ERROR, "Failed to allocate Policy structure\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto Exit;
-  }  
- 
+  }
+
   // We only translate the GFX ports #0 exposed to platform from conf data
   GfxSiliconPolicy[0].Power_State_Port = GfxEnablePort0;
 
@@ -82,7 +82,7 @@ ApplyGfxConfigToPolicy (
 
 Exit:
   if (GfxSiliconPolicy != NULL) {
-    FreePool (GfxSiliconPolicy);   
+    FreePool (GfxSiliconPolicy);
   }
 
   return Status;

--- a/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
+++ b/Platforms/QemuQ35Pkg/ConfigKnobs/ConfigDataGfx/ConfigDataGfx.c
@@ -64,16 +64,23 @@ ApplyGfxConfigToPolicy (
   GfxEnablePort0   = *(BOOLEAN *)ConfigBuffer;
   GfxSiliconPolicy = AllocateCopyPool (sizeof (DefaultQemuGfxPolicy), DefaultQemuGfxPolicy);
 
+  if (GfxSiliconPolicy == NULL) {
+    DEBUG ((DEBUG_ERROR, "Failed to allocate Policy structure\n"));
+    goto Exit;
+  }  // Mu
+ 
   // We only translate the GFX ports #0 exposed to platform from conf data
   GfxSiliconPolicy[0].Power_State_Port = GfxEnablePort0;
 
   Status = SetPolicy (&gPolicyDataGFXGuid, POLICY_ATTRIBUTE_FINALIZED, GfxSiliconPolicy, sizeof (DefaultQemuGfxPolicy));
+
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to update GFX policy per configuration data - %r!!!\n", __func__, Status));
     ASSERT (FALSE);
+    FreePool (GfxSiliconPolicy);   //Mu
     goto Exit;
   }
-
+  FreePool (GfxSiliconPolicy);   //Mu
 Exit:
   return Status;
 }


### PR DESCRIPTION
## Description

Fixes #632 

This change is responsive to https://github.com/microsoft/mu_tiano_platforms/issues/632. It fixes a memory leak and also defends against a failed memory allocation.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Build test and boot to shell using QEMU

## Integration Instructions

N/A