### PR TITLE
Bump MU_BASECORE from 2024050000.1.4 to 2024050003.0.1

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -54,12 +54,14 @@
   DXE_CRYPTO_SERVICES = STANDARD
   RUNTIMEDXE_CRYPTO_SERVICES = STANDARD
   SMM_CRYPTO_SERVICES = NONE
-  STANDALONEMM_CRYPTO_SERVICES = STANDARD
+  STANDALONEMM_CRYPTO_SERVICES = NONE
+  STANDALONEMM_MMSUPV_CRYPTO_SERVICES = STANDARD
   PEI_CRYPTO_ARCH = IA32
   DXE_CRYPTO_ARCH = X64
   RUNTIMEDXE_CRYPTO_ARCH = X64
   SMM_CRYPTO_ARCH = NONE
-  STANDALONEMM_CRYPTO_ARCH = X64
+  STANDALONEMM_CRYPTO_ARCH = NONE
+  STANDALONEMM_MMSUPV_CRYPTO_ARCH = X64
 
 ################################################################################
 #
@@ -320,6 +322,8 @@
   StackCheckFailureHookLib|MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
 
   HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
+
+  MemoryBinOverrideLib|MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf
 
 [LibraryClasses.IA32, LibraryClasses.X64]
   XenHypercallLib|QemuQ35Pkg/Library/XenHypercallLib/XenHypercallLib.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -366,6 +366,8 @@
 [LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.MM_STANDALONE]
   MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
 
+  PeCoffLibNegative|SeaPkg/Library/BasePeCoffLibNegative/BasePeCoffLibNegative.inf
+  SecurePolicyLib|MmSupervisorPkg/Library/SecurePolicyLib/SecurePolicyLib.inf
 #########################################
 # PEI Libraries
 #########################################

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -514,7 +514,7 @@ INF  MsCorePkg/AcpiRGRT/AcpiRgrt.inf
 
 !if $(SMM_ENABLED) == TRUE
   !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.DXE.inc.fdf
-  !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.STANDALONEMM.inc.fdf
+  !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.STANDALONEMM_MMSUPV.inc.fdf
 !else
   !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.RUNTIMEDXE.inc.fdf
 !endif

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.ci.yaml
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.ci.yaml
@@ -140,7 +140,8 @@
             "dmaivrs",
             "nxcompat",
             "standalonemm",
-            "runtimedxe"
+            "runtimedxe",
+            "mmsupv",
         ],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -76,14 +76,14 @@
   PEI_CRYPTO_SERVICES                 = TINY_SHA
   DXE_CRYPTO_SERVICES                 = STANDARD
   RUNTIMEDXE_CRYPTO_SERVICES          = NONE
-  STANDALONEMM_CRYPTO_SERVICES        = None
-  STANDALONEMM_MMSUPV_CRYPTO_SERVICES = STANDARD
+  STANDALONEMM_CRYPTO_SERVICES        = STANDARD
+  STANDALONEMM_MMSUPV_CRYPTO_SERVICES = NONE
   SMM_CRYPTO_SERVICES                 = NONE
   PEI_CRYPTO_ARCH                     = AARCH64
   DXE_CRYPTO_ARCH                     = AARCH64
   RUNTIMEDXE_CRYPTO_ARCH              = NONE
-  STANDALONEMM_CRYPTO_ARCH            = NONE 
-  STANDALONEMM_MMSUPV_CRYPTO_ARCH     = AARCH64
+  STANDALONEMM_CRYPTO_ARCH            = AARCH64
+  STANDALONEMM_MMSUPV_CRYPTO_ARCH     = NONE
   SMM_CRYPTO_ARCH                     = NONE
 
 !if $(NETWORK_SNP_ENABLE) == TRUE
@@ -508,6 +508,7 @@
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
   MemoryTypeInfoSecVarCheckLib|MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.inf
   FltUsedLib|MdePkg/Library/FltUsedLib/FltUsedLib.inf
+
 
 [LibraryClasses.common.UEFI_DRIVER]
   UefiScsiLib|MdePkg/Library/UefiScsiLib/UefiScsiLib.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -73,16 +73,18 @@
   DEFINE NETWORK_ALLOW_HTTP_CONNECTIONS  = TRUE
   DEFINE NETWORK_ISCSI_ENABLE            = FALSE
 
-  PEI_CRYPTO_SERVICES           = TINY_SHA
-  DXE_CRYPTO_SERVICES           = STANDARD
-  RUNTIMEDXE_CRYPTO_SERVICES    = NONE
-  STANDALONEMM_CRYPTO_SERVICES  = STANDARD
-  SMM_CRYPTO_SERVICES           = NONE
-  PEI_CRYPTO_ARCH               = AARCH64
-  DXE_CRYPTO_ARCH               = AARCH64
-  RUNTIMEDXE_CRYPTO_ARCH        = NONE
-  STANDALONEMM_CRYPTO_ARCH      = AARCH64
-  SMM_CRYPTO_ARCH               = NONE
+  PEI_CRYPTO_SERVICES                 = TINY_SHA
+  DXE_CRYPTO_SERVICES                 = STANDARD
+  RUNTIMEDXE_CRYPTO_SERVICES          = NONE
+  STANDALONEMM_CRYPTO_SERVICES        = None
+  STANDALONEMM_MMSUPV_CRYPTO_SERVICES = STANDARD
+  SMM_CRYPTO_SERVICES                 = NONE
+  PEI_CRYPTO_ARCH                     = AARCH64
+  DXE_CRYPTO_ARCH                     = AARCH64
+  RUNTIMEDXE_CRYPTO_ARCH              = NONE
+  STANDALONEMM_CRYPTO_ARCH            = NONE 
+  STANDALONEMM_MMSUPV_CRYPTO_ARCH     = AARCH64
+  SMM_CRYPTO_ARCH                     = NONE
 
 !if $(NETWORK_SNP_ENABLE) == TRUE
   !error "NETWORK_SNP_ENABLE is IA32/X64/EBC only"
@@ -377,6 +379,8 @@
   TransportLogControlLib|DebuggerFeaturePkg/Library/TransportLogControlLibNull/TransportLogControlLibNull.inf
 
   HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
+
+  MemoryBinOverrideLib|MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf
 
 [LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE]
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -531,7 +531,7 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 
   INF StandaloneMmPkg/Core/StandaloneMmCore.inf
-  !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.STANDALONEMM.inc.fdf
+  !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.STANDALONEMM_MMSUPV.inc.fdf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
   INF QemuSbsaPkg/VirtNorFlashStandaloneMm/VirtNorFlashStandaloneMm.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -531,7 +531,7 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 
   INF StandaloneMmPkg/Core/StandaloneMmCore.inf
-  !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.STANDALONEMM_MMSUPV.inc.fdf
+  !include $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.STANDALONEMM.inc.fdf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
   INF QemuSbsaPkg/VirtNorFlashStandaloneMm/VirtNorFlashStandaloneMm.inf


### PR DESCRIPTION
Bumps MU_BASECORE from `2024050000.1.4` to `2024050003.0.0`
Bumps MM_SUPV from `v14.0.2` to `v15.0.0.`



Signed-off-by: Project Mu Bot <mubot@microsoft.com>