### PR TITLE
[FF-A] Use Updated Service GUIDs

### DIFF
--- a/Platforms/QemuSbsaPkg/MsSecurePartition/MsSecurePartition.c
+++ b/Platforms/QemuSbsaPkg/MsSecurePartition/MsSecurePartition.c
@@ -23,10 +23,8 @@
 #include <Library/TestServiceLib.h>
 #include <Library/TpmServiceLib.h>
 #include <Guid/Tpm2ServiceFfa.h>
-
-// Service specific structures/variables
-EFI_GUID  NotificationServiceGuid = NOTIFICATION_SERVICE_UUID;
-EFI_GUID  TestServiceGuid         = TEST_SERVICE_UUID;
+#include <Guid/NotificationServiceFfa.h>
+#include <Guid/TestServiceFfa.h>
 
 /**
   Message Handler for the Microsoft Secure Partition
@@ -47,11 +45,11 @@ MsSecurePartitionHandleMessage (
   Response->SourceId      = Request->DestinationId;
   Response->DestinationId = Request->SourceId;
 
-  if (!CompareMem (&Request->ServiceGuid, &NotificationServiceGuid, sizeof (EFI_GUID))) {
+  if (!CompareMem (&Request->ServiceGuid, &gEfiNotificationServiceFfaGuid, sizeof (EFI_GUID))) {
     NotificationServiceHandle (Request, Response);
   } else if (!CompareMem (&Request->ServiceGuid, &gEfiTpm2ServiceFfaGuid, sizeof (EFI_GUID))) {
     TpmServiceHandle (Request, Response);
-  } else if (!CompareMem (&Request->ServiceGuid, &TestServiceGuid, sizeof (EFI_GUID))) {
+  } else if (!CompareMem (&Request->ServiceGuid, &gEfiTestServiceFfaGuid, sizeof (EFI_GUID))) {
     TestServiceHandle (Request, Response);
   } else {
     DEBUG ((DEBUG_ERROR, "Invalid secure partition service UUID\n"));

--- a/Platforms/QemuSbsaPkg/MsSecurePartition/MsSecurePartition.inf
+++ b/Platforms/QemuSbsaPkg/MsSecurePartition/MsSecurePartition.inf
@@ -46,6 +46,8 @@
 [Guids]
   gMmCoreDataHobGuid
   gEfiTpm2ServiceFfaGuid
+  gEfiNotificationServiceFfaGuid
+  gEfiTestServiceFfaGuid
 
 #
 # This configuration fails for CLANGPDB, which does not support PIE in the GCC


### PR DESCRIPTION
## Description

Using the new global GUIDs for the services in MsSecurePartition.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified using the FfaPartitionTestApp.

## Integration Instructions

N/A
