### PR TITLE
[FFA] Fixed an issue of symbol unresolved when enabling TPM

### DIFF
--- a/Platforms/QemuSbsaPkg/MsSecurePartition/MsSecurePartition.c
+++ b/Platforms/QemuSbsaPkg/MsSecurePartition/MsSecurePartition.c
@@ -83,7 +83,6 @@ MsSecurePartitionMain (
   NotificationServiceInit ();
  #ifdef TPM2_ENABLE
   TpmServiceInit ();
-  #error "TPM2_ENABLE is defined"
  #endif
   TestServiceInit ();
 

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1456,7 +1456,7 @@
       Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibVerbose.inf
       TimerLib|ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.inf
 !if $(TPM2_ENABLE) == TRUE
-      TpmServiceLib|ArmPkg/Library/TpmServiceLib/TpmServiceLib.inf
+      NULL|ArmPkg/Library/TpmServiceLib/TpmServiceLib.inf
 !endif
     <PcdsFixedAtBuild>
       gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x60030000


### PR DESCRIPTION
## Description

The `TpmServiceLib` is not linkable when there is library class specified because its inf does not pertain the same logic of linking `TpmServiceLib`.

This change moved it to NULL library class so that it will be linked according to the build flag.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested buildable for QEMU SBSA.

## Integration Instructions

N/A
