### PR TITLE
use external dependency for cargo tools on windows

### DIFF
--- a/QemuPkg/Binaries/cargo-make_ext_dep.yaml
+++ b/QemuPkg/Binaries/cargo-make_ext_dep.yaml
@@ -1,0 +1,18 @@
+##
+# Downloads the exact version of cargo-make. This version should be the same version as that found in the
+# rust-toolchain.toml file.
+#
+# Copyright (c) 2019, Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+  "scope": "global-win",
+  "type": "web",
+  "name": "cargo-make",
+  "source": "https://github.com/sagiegurari/cargo-make/releases/download/0.37.9/cargo-make-v0.37.9-x86_64-pc-windows-msvc.zip",
+  "version": "v0.37.9",
+  "sha256": "4d4c45546402e6edf387348f9e83281cc1415b0990c69a31a4462a81b43b8835",
+  "internal_path": "/",
+  "compression_type": "zip",
+  "flags": ["set_path"],
+}

--- a/QemuPkg/Binaries/cargo-tarpaulin_ext_dep.yaml
+++ b/QemuPkg/Binaries/cargo-tarpaulin_ext_dep.yaml
@@ -1,0 +1,18 @@
+##
+# Downloads the exact version of cargo-tarpaulin. This version should be the same version as that found in the
+# rust-toolchain.toml file.
+#
+# Copyright (c) 2019, Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+  "scope": "global-win",
+  "type": "web",
+  "name": "cargo-tarpaulin",
+  "source": "https://github.com/xd009642/tarpaulin/releases/download/0.31.5/cargo-tarpaulin-x86_64-pc-windows-msvc.zip",
+  "version": "v0.31.5",
+  "sha256": "96d93282bcd9c8e52fbe1dab2dff023512f198b5f0cff375c2fbce12fd978c5e",
+  "internal_path": "/",
+  "compression_type": "zip",
+  "flags": ["set_path"],
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,10 @@
 [toolchain]
 channel = "1.80.0"
 
+# For Windows, these tools are external dependencies found at QemuPkg/Binaries. If updating the version here, the
+# version in QemuPkg/Binaries/README.md should also be updated.
+
+# For Linux, these tools, come from the devcontainer found at .devcontainer/devcontainer.json.
 [tools]
 cargo-make = "0.37.9"
 cargo-tarpaulin = "0.31.2"


### PR DESCRIPTION
## Description

Cargo tools (tarpaulin / make) are provided for free when using the provided devcontainer. However, on Windows, these tools must be installed or downloaded manually at a specific version. This has caused frequent issues for developers as local installation via compilation tend to fail as this project uses an outdated version of rust.

This change adds these tools as external dependencies, so that developers who only care about compiling the project can do so without having to worry about installing these additional tools.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Removed my installation of cargo-make and cargo-tarpaulin and was still able to run stuart_build and stuart_ci_build

## Integration Instructions

N/A
