### PR TITLE
devcontainer.json: Use Ubuntu 24.04

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/microsoft/mu_devops/ubuntu-22-dev:latest",
+  "image": "ghcr.io/microsoft/mu_devops/ubuntu-24-dev:latest",
   "postCreateCommand": "git config --global --add safe.directory '*' && pip install --upgrade -r pip-requirements.txt",
   "forwardPorts": [ // For general use. EXDI, TCP Serial, etc.
     5005,


### PR DESCRIPTION
## Description

Updates the dev container to use the ubuntu-24-dev image.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Set up devcontainer locally in VS Code.

## Integration Instructions

- N/A