### PR TITLE
Add Performance Tracing Support

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -499,6 +499,9 @@ INF MsCorePkg/LoadOptionVariablePolicyDxe/LoadOptionVariablePolicyDxe.inf
 !if $(SMM_ENABLED) == TRUE
 INF  MmSupervisorPkg/Drivers/MmSupervisorRing3Broker/MmSupervisorRing3Broker.inf
 INF  MmSupervisorPkg/Drivers/StandaloneMmUnblockMem/StandaloneMmUnblockMem.inf
+!if $(PERF_TRACE_ENABLE) == TRUE
+INF  MmSupervisorPkg/Drivers/MmSupervisorRing3Performance/MmSupervisorRing3Performance.inf
+!endif
 !endif
 # INF RuleOverride = DRIVER_ACPITABLE SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.inf
 # COMMENTED OUT DUE TO LACK OF TPM


### PR DESCRIPTION
## Description

Closes #1115 

Allows performance tracing to be enabled with Standalone MM.

Performance tracing is only enabled when the `PERF_TRACE_ENABLE` build flag is set to `TRUE`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Build and CI.
- Test getting performance record from a Standalone MM driver.
- Verify that the FPDT MMI handler in `StandaloneMmCorePerformanceLib` returns back perf records as expected.
- Verify perf records returned from the MMI handler in Traditional SMM before and after perf lib changes.

## Integration Instructions

- N/A - Integrates changes into this repo.