### PR TITLE
[REBASE&FF] Re-enable Rust CI

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -85,6 +85,7 @@ jobs:
     linux_container_image: ghcr.io/microsoft/mu_devops/ubuntu-24-build:d412ccd
     ${{ if eq(parameters.rust_build, true) }}:
       linux_container_options: --security-opt seccomp=unconfined
+      extra_build_args: --rust CODE_COVERAGE=TRUE CC_FLATTEN=TRUE CC_FULL=TRUE
     do_ci_build: ${{ parameters.do_ci_build }}
     do_ci_setup: ${{ parameters.do_ci_setup }}
     do_pr_eval: ${{ parameters.do_pr_eval }}

--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -35,7 +35,7 @@ jobs:
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -49,7 +49,7 @@ jobs:
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -95,7 +95,7 @@ jobs:
         BuildTarget: "RELEASE"
         BuildExtraTag: "NO_SMM"
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE BLD_*_QEMU_CORE_NUM=2 BLD_*_SMM_ENABLED=FALSE"
         BuildArtifactsBinary: |
@@ -111,7 +111,6 @@ jobs:
         BuildExtraStep:
           - script: sudo apt-get install -y libssl-dev
             displayName: Install openssl
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -128,7 +127,6 @@ jobs:
         BuildExtraStep:
           - script: sudo apt-get install -y libssl-dev
             displayName: Install openssl
-          - template: Steps/RustSetupSteps.yml@mu_devops
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -163,6 +161,37 @@ jobs:
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         SelfHostAgent: true
+        BuildArtifactsBinary: |
+          **/QEMU_EFI.fd
+          **/SECURE_FLASH0.fd
+        BuildArtifactsOther: "**/unit_test_results/*"
+
+      QemuQ35_Rust_DEBUG:
+        BuildPackage: QemuQ35Pkg
+        BuildFile: "Platforms/QemuQ35Pkg/PlatformBuild.py"
+        BuildFlags: "--rust"
+        BuildTarget: "DEBUG"
+        BuildExtraTag: ""
+        BuildExtraStep:
+          - template: Steps/RustSetupSteps.yml@mu_devops
+        Run: true
+        RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2"
+        BuildArtifactsBinary: |
+          **/QEMUQ35_*.fd
+        BuildArtifactsOther: "**/unit_test_results/*"
+
+      QemuSbsa_Rust_DEBUG:
+        BuildPackage: QemuSbsaPkg
+        BuildFile: "Platforms/QemuSbsaPkg/PlatformBuild.py"
+        BuildFlags: "--rust"
+        BuildTarget: "DEBUG"
+        BuildExtraTag: ""
+        BuildExtraStep:
+          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: sudo apt-get install -y libssl-dev
+            displayName: Install openssl
+        Run: true
+        RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE"
         BuildArtifactsBinary: |
           **/QEMU_EFI.fd
           **/SECURE_FLASH0.fd

--- a/.azurepipelines/Platform-Build-VS.yml
+++ b/.azurepipelines/Platform-Build-VS.yml
@@ -32,7 +32,7 @@ jobs:
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -46,7 +46,7 @@ jobs:
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -92,7 +92,7 @@ jobs:
         BuildTarget: "RELEASE"
         BuildExtraTag: "NO_SMM"
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE BLD_*_QEMU_CORE_NUM=2 BLD_*_SMM_ENABLED=FALSE"
         BuildArtifactsBinary: |
@@ -138,7 +138,7 @@ jobs:
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -152,7 +152,7 @@ jobs:
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
+          - script: echo No extra steps provided
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
         BuildArtifactsBinary: |
@@ -165,7 +165,6 @@ jobs:
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
           - template: Steps/SetupToolChainTagPreReqs.yml@mu_devops
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"
@@ -181,7 +180,6 @@ jobs:
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
         BuildExtraStep:
-          - template: Steps/RustSetupSteps.yml@mu_devops
           - template: Steps/SetupToolChainTagPreReqs.yml@mu_devops
         Run: true
         RunFlags: "SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE TEST_REGEX=*TestApp*.efi RUN_TESTS=TRUE"

--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -28,6 +28,7 @@ extends:
     do_pr_eval: true
     container_build: true
     os_type: Linux
+    rust_build: true
     extra_cargo_steps:
       - script: pip install -r pip-requirements.txt --upgrade
         displayName: Install and Upgrade pip Modules

--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -27,6 +27,7 @@ extends:
     do_non_ci_setup: true
     do_pr_eval: true
     os_type: Windows_NT
+    rust_build: true
     extra_cargo_steps:
       - script: pip install -r pip-requirements.txt --upgrade
         displayName: Install and Upgrade pip Modules

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -28,10 +28,11 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
     # ####################################################################################### #
 
     def AddCommandLineOptions(self, parserObj):
-        pass
+        parserObj.add_argument("-r", "--rust", dest="rust_ci", action="store_true", help="Runs CI with Rust CI checks enabled")
+
 
     def RetrieveCommandLineOptions(self, args):
-        pass
+        self.rust_ci = args.rust_ci
 
     # ####################################################################################### #
     #                        Default Support for this Ci Build                                #
@@ -109,6 +110,9 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
     def GetActiveScopes(self):
         ''' return tuple containing scopes that should be active for this process '''
         scopes = ("cibuild", "edk2-build", "host-based-test")
+
+        if self.rust_ci:
+            scopes += ("rust-ci",)
 
         self.ActualToolChainTag = shell_environment.GetBuildVars().GetValue("TOOL_CHAIN_TAG", "")
 

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -7,6 +7,7 @@
 import datetime
 import logging
 import os
+from typing import Tuple
 import uuid
 from io import StringIO
 from pathlib import Path
@@ -56,11 +57,39 @@ class CommonPlatform():
         "Features/CONFIG"
     )
 
+    @staticmethod
+    def add_common_command_line_options(parserObj) -> None:
+        """Add common command line options to the parser object."""
+        parserObj.add_argument("-r", "--rust", dest="build_rust", action="store_true", help="Builds this platform with additional Rust components (And some C components removed).")
+
+    @staticmethod
+    def get_common_command_line_options(settings, args) -> None:
+        """Retrieves command line options common to settings managers."""
+        settings.build_rust = args.build_rust
+    
+    @staticmethod
+    def get_active_scopes(build_rust: bool) -> Tuple[str]:
+        scopes = CommonPlatform.Scopes
+
+        if build_rust:
+            scopes += ("rust",)
+
+        actual_tool_chain_tag = shell_environment.GetBuildVars().GetValue(
+                "TOOL_CHAIN_TAG", ""
+            )
+        if actual_tool_chain_tag.upper().startswith("GCC"):
+            scopes += ("gcc_aarch64_linux",)
+        return scopes
 
     # ####################################################################################### #
     #                         Configuration for Update & Setup                                #
     # ####################################################################################### #
 class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSettingsManager, ParseSettingsManager):
+    def AddCommandLineOptions(self, parserObj):
+        CommonPlatform.add_common_command_line_options(parserObj)
+
+    def RetrieveCommandLineOptions(self, args):
+        CommonPlatform.get_common_command_line_options(self, args)
 
     def GetPackagesSupported(self):
         ''' return iterable of edk2 packages supported by this build.
@@ -114,13 +143,7 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
 
     def GetActiveScopes(self):
         ''' return tuple containing scopes that should be active for this process '''
-        scopes = CommonPlatform.Scopes
-        actual_tool_chain_tag = shell_environment.GetBuildVars().GetValue(
-                "TOOL_CHAIN_TAG", ""
-            )
-        if actual_tool_chain_tag.upper().startswith("GCC"):
-            scopes += ("gcc_aarch64_linux",)
-        return scopes
+        return CommonPlatform.get_active_scopes(self.build_rust)
 
     def FilterPackagesToTest(self, changedFilesList: list, potentialPackagesList: list) -> list:
         ''' Filter other cases that this package should be built
@@ -163,6 +186,12 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
 class PlatformBuilder(UefiBuilder, BuildSettingsManager):
     def __init__(self):
         UefiBuilder.__init__(self)
+
+    def AddCommandLineOptions(self, parserObj):
+        CommonPlatform.add_common_command_line_options(parserObj)
+
+    def RetrieveCommandLineOptions(self, args):
+        CommonPlatform.get_common_command_line_options(self, args)
 
     # Helper function to query the VC variables of interest and inject them into the environment
     def InjectVcVarsOfInterests(self, vcvars: list):
@@ -230,13 +259,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
     def GetActiveScopes(self):
         ''' return tuple containing scopes that should be active for this process '''
-        scopes = CommonPlatform.Scopes
-        actual_tool_chain_tag = shell_environment.GetBuildVars().GetValue(
-                "TOOL_CHAIN_TAG", ""
-            )
-        if actual_tool_chain_tag.upper().startswith("GCC"):
-            scopes += ("gcc_aarch64_linux",)
-        return scopes
+        return CommonPlatform.get_active_scopes(self.build_rust)
 
     def GetName(self):
         ''' Get the name of the repo, platform, or product being build '''
@@ -274,6 +297,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         self.env.SetValue("ACTIVE_PLATFORM", "QemuSbsaPkg/QemuSbsaPkg.dsc", "Platform Hardcoded")
         self.env.SetValue("TARGET_ARCH", "AARCH64", "Platform Hardcoded")
         self.env.SetValue("TOOL_CHAIN_TAG", "GCC5", "set default to gcc5")
+        self.env.SetValue("BLD_*_BUILD_RUST_CODE", str(self.build_rust).upper(), "Set via `--rust` command line option")
         self.env.SetValue("EMPTY_DRIVE", "FALSE", "Default to false")
         self.env.SetValue("RUN_TESTS", "FALSE", "Default to false")
         self.env.SetValue("QEMU_HEADLESS", "FALSE", "Default to false")


### PR DESCRIPTION
## Description

Closes #1113 

Adds a new command line argument to all Build Files (`QemuQ35Pkg/PlatformBuild.py`, `QemuSbsaPkg/PlatformBuild.py`, `.pytool/CISettings.py`), `--rust`, which adds the `rust-ci` scope and adds in rust components to the platform.

Additionally updates the CI system to add two new runners to test:
- Linux, Debug, QemuQ35Pkg + Rust
- Linux, Debug, QemuSbsaPkg + Rust

Finally, re-enables rust in all CI builds (`stuart_ci_build`) by adding the `--rust` flag.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

All Platforms continue to build and pass, both with rust and non-rust builds. rust CI is ran with `stuart_ci_build` when the `--rust` flag is added, including on CI Runners

## Integration Instructions

N/A