### PR TITLE
Enable LineParserTestApp Again

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -30,7 +30,6 @@ WORKSPACE_ROOT = str(Path(__file__).parent.parent.parent)
 # Declare test whose failure will not return a non-zero exit code
 FAILURE_EXEMPT_TESTS = {
     # example "PiValueTestApp.efi": datetime.datetime(3141, 5, 9, 2, 6, 53, 589793),
-    "LineParserTestApp.efi": datetime.datetime(2025, 2, 12, 0, 0, 0, 0)
 }
 
 # Allow failure exempt tests to be ignored for 90 days

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -26,8 +26,7 @@ from edk2toollib.utility_functions import GetHostInfo
 # Declare test whose failure will not return a non-zero exit code
 FAILURE_EXEMPT_TESTS = {
     # example "PiValueTestApp.efi": datetime.datetime(3141, 5, 9, 2, 6, 53, 589793),
-    "LineParserTestApp.efi": datetime.datetime(2025, 2, 12, 0, 0, 0, 0)
-}
+    }
 
 # Allow failure exempt tests to be ignored for 90 days
 FAILURE_EXEMPT_OMISSION_LENGTH = 90*24*60*60


### PR DESCRIPTION
## Description

Was broken for a while due to some earlier adv logger changes. Temporarily exempted to unblock Mu Plus updates in: https://github.com/microsoft/mu_tiano_platforms/commit/7970218c141eec9f9e76fc78391acb70837eca92

Issues fixed in:
https://github.com/microsoft/mu_plus/commit/4ac6d20a719cf7128cc45088b22f49ad1d1f5cef

Enabled again here with that submodule update.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run LineParserTestApp in EFI shell

## Integration Instructions

- N/A