### PR TITLE
[FF-A] Update HAF Submodule

### DIFF
--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -12,6 +12,7 @@ import uuid
 from io import StringIO
 from pathlib import Path
 import json
+import shutil
 
 from edk2toolext.environment import shell_environment
 from edk2toolext.environment.uefi_build import UefiBuilder
@@ -340,6 +341,17 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         return 0
 
     def PlatformPostBuild(self):
+        src_dir = os.path.join(self.GetWorkspaceRoot (), "Platforms/QemuSbsaPkg/mu")
+        dest_dir = os.path.join(self.GetWorkspaceRoot (), "Silicon/Arm/HAF/project/mu")
+
+        # Remove the directory if it exists
+        if os.path.exists(dest_dir):
+            shutil.rmtree(dest_dir)
+
+        # Copy the mu directory and its contents
+        logging.info("Copying mu directory to Silicon/Arm/HAF/project")
+        shutil.copytree(src_dir, dest_dir)
+
         # Add a post build step to build BL31 and assemble the FD files
         op_fv = os.path.join(self.env.GetValue("BUILD_OUTPUT_BASE"), "FV")
 

--- a/Platforms/QemuSbsaPkg/mu/AUTHORS
+++ b/Platforms/QemuSbsaPkg/mu/AUTHORS
@@ -1,0 +1,9 @@
+# This is the list of Hafnium authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+#
+# Please keep the list sorted alphabetically.
+Arm Ltd.
+Google LLC

--- a/Platforms/QemuSbsaPkg/mu/AUTHORS
+++ b/Platforms/QemuSbsaPkg/mu/AUTHORS
@@ -7,3 +7,4 @@
 # Please keep the list sorted alphabetically.
 Arm Ltd.
 Google LLC
+Microsoft

--- a/Platforms/QemuSbsaPkg/mu/BUILD.gn
+++ b/Platforms/QemuSbsaPkg/mu/BUILD.gn
@@ -1,4 +1,5 @@
 # Copyright 2018 The Hafnium Authors.
+# Copyright (c) Microsoft Corporation.
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at

--- a/Platforms/QemuSbsaPkg/mu/BUILD.gn
+++ b/Platforms/QemuSbsaPkg/mu/BUILD.gn
@@ -1,0 +1,60 @@
+# Copyright 2018 The Hafnium Authors.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/BSD-3-Clause.
+
+import("//build/toolchain/embedded.gni")
+import("//build/toolchain/host.gni")
+
+group("secure_qemu_aarch64") {
+  deps = [ "//src:hafnium(:secure_qemu_aarch64_clang)" ]
+}
+
+group("root") {
+  deps = [
+    ":secure_qemu_aarch64",
+  ]
+}
+
+group("test_root") {
+  testonly = true
+
+  deps = [
+    "//src:unit_tests(:host_fake_clang)",
+  ]
+}
+
+# Describe each of the platforms used in this project.
+
+host_toolchain("host_fake") {
+  use_platform = true
+  heap_pages = 60
+  max_cpus = 4
+  max_vms = 6
+}
+
+aarch64_toolchains("secure_qemu_aarch64") {
+  cpu = "cortex-a57"
+  origin_address = "0x30000000"
+  memory_protect = "//src/memory_protect:absent"
+  boot_flow = "//src/boot_flow:spmc"
+  console = "//src/arch/aarch64/pl011"
+  iommu = "//src/iommu:absent"
+  gic_version = 3
+  gicd_base_address = "0x40060000"
+  gicr_base_address = "0x40080000"
+  gicr_frames = 8
+  heap_pages = 180
+  max_cpus = 8
+  max_vms = 16
+  toolchain_args = {
+    ffa_role = "//src/ffa:spmc"
+    plat_psci = "//src/arch/aarch64/plat/psci:spmc"
+    plat_interrupts = "//src/arch/aarch64/plat/interrupts:gicv3"
+    secure_world = "1"
+    pl011_base_address = "0x60000000"
+    plat_log_level = "LOG_LEVEL_VERBOSE"
+    plat_num_virtual_interrupts_ids = 1024
+  }
+}

--- a/Platforms/QemuSbsaPkg/mu/LICENSE
+++ b/Platforms/QemuSbsaPkg/mu/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2020 The Hafnium Authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Platforms/QemuSbsaPkg/mu/LICENSE
+++ b/Platforms/QemuSbsaPkg/mu/LICENSE
@@ -1,4 +1,5 @@
 Copyright 2020 The Hafnium Authors
+Copyright (c) Microsoft Corporation.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/Platforms/QemuSbsaPkg/mu/secure_qemu_aarch64/BUILD.gn
+++ b/Platforms/QemuSbsaPkg/mu/secure_qemu_aarch64/BUILD.gn
@@ -1,0 +1,8 @@
+# Copyright 2023 The Hafnium Authors.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/BSD-3-Clause.
+
+source_set("secure_qemu_aarch64") {
+}

--- a/Platforms/QemuSbsaPkg/mu/secure_qemu_aarch64/BUILD.gn
+++ b/Platforms/QemuSbsaPkg/mu/secure_qemu_aarch64/BUILD.gn
@@ -1,4 +1,5 @@
 # Copyright 2023 The Hafnium Authors.
+# Copyright (c) Microsoft Corporation.
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at


### PR DESCRIPTION
## Description

Updated the HAF submodule to be top of tree from ARM trusted firmware. Added python code to PlatformBuild.py to copy the mu directory and its contents to Silicon/Arm/HAF/project which is needed for building our mu project.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified by building the QemuSbsa build and seeing the output in QEMU. Secure partitions are launched and working.

## Integration Instructions

N/A
