### PR TITLE
QemuSbsaPkg: Move pip install to pip-requirements

### DIFF
--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -483,7 +483,6 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             f.write("poetry --verbose install\n")
             f.write("poetry env activate\n")
             f.write("poetry show\n")
-            f.write("pip3 install fdt\n") # why is this still needed?
             f.write(f"{cmd} {args}\n")
 
         # Grab the current head to restore from patches later.

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -18,5 +18,6 @@ xmlschema==4.0.1
 regex==2024.11.6
 pygount==3.1.0
 pywin32==310; sys_platform == 'win32'
-setuptools
-poetry
+setuptools==80.9.0
+poetry==2.1.3
+fdt==0.3.3


### PR DESCRIPTION
## Description

a call to pip3 install was directly embedded into the platform build.
Move it to pip-requirements to allow strongly versioning.
Add versions for other requirements to prevent floating on latest versions.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local build in WSL for SBSA.

## Integration Instructions
No integration necessary.