### PR TITLE
Use update PlatformBuild/CIsettings to limit recursive downloading 

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -129,14 +129,14 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
             If no RequiredSubmodules return an empty iterable
         """
         return [
-            RequiredSubmodule("MU_BASECORE", True),
-            RequiredSubmodule("Common/MU", True),
-            RequiredSubmodule("Common/MU_TIANO", True),
-            RequiredSubmodule("Common/MU_OEM_SAMPLE", True),
-            RequiredSubmodule("Features/DEBUGGER", True),
-            RequiredSubmodule("Features/DFCI", True),
-            RequiredSubmodule("Features/CONFIG", True),
-            RequiredSubmodule("Features/MM_SUPV", True),
+            RequiredSubmodule("MU_BASECORE", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Common/MU", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Common/MU_TIANO", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Common/MU_OEM_SAMPLE", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Features/DEBUGGER", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Features/DFCI", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Features/CONFIG", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Features/MM_SUPV", False, ".pytool/CISettings.py"),
         ]
 
     def SetArchitectures(self, list_of_requested_architectures):

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -118,11 +118,11 @@ class SettingsManager(UpdateSettingsManager, SetupSettingsManager, PrEvalSetting
             If no RequiredSubmodules return an empty iterable
         """
         return [
-            RequiredSubmodule("MU_BASECORE", True),
-            RequiredSubmodule("Common/MU", True),
-            RequiredSubmodule("Common/MU_TIANO", True),
-            RequiredSubmodule("Common/MU_OEM_SAMPLE", True),
-            RequiredSubmodule("Silicon/Arm/MU_TIANO", True),
+            RequiredSubmodule("MU_BASECORE", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Common/MU", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Common/MU_TIANO", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Common/MU_OEM_SAMPLE", False, ".pytool/CISettings.py"),
+            RequiredSubmodule("Silicon/Arm/MU_TIANO", False, ".pytool/CISettings.py"),
             RequiredSubmodule("Silicon/Arm/TFA", True),
             RequiredSubmodule("Silicon/Arm/HAF", True),
             RequiredSubmodule("Features/DEBUGGER", True),
@@ -506,7 +506,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         ret = RunCmd("bash", temp_bash, workingdir=self.env.GetValue("ARM_TFA_PATH"), environ=cached_enivron)
         if patch_tfa:
             # Always revert before returning
-            revert_ret = RunCmd(f"git", f"checkout {arm_tfa_git_head}", workingdir=self.env.GetValue("ARM_TFA_PATH"), environ=cached_enivron)
+            revert_ret = RunCmd("git", f"checkout {arm_tfa_git_head}", workingdir=self.env.GetValue("ARM_TFA_PATH"), environ=cached_enivron)
             if revert_ret != 0:
                 return revert_ret
 


### PR DESCRIPTION
## Description

Use updated stuart tools to limit recursive downloading from mu repositories.

When a platform identifies submodules through GetRequiredSubmodules()
it previously only contained True/False for specifying the need for
submodules. If True, it would recursively clone all submodules.

This modification allows specifying a CiSettings file containing a
CiSetupSettingsManager instance, and will attempt to only download
the submodules specified in the GetRequiredSubmodules section.

GetDependencies() does not have configuration for this type of scenario.
A Dependency from GetDependencies will always attempt to resolve **ALL** submodules that are contained in the repo.

This presents a problem when a submodule contains their own dependency as well. The example run into is:

SecurityPkg => libspdm
libspdm => openssl
openssl => gost-engine
gost-engine => libprov

This is being implemented in mu_tiano_platforms for reference so that other projects can see how to prevent security advisories introduced by the unused submodules. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local Builds verifying that limited downloading still builds/boots.

## Integration Instructions
No integration necessary. 