### PR TITLE
Fix TF-A and hafnium build

### DIFF
--- a/.azurepipelines/Platform-Build-GCC5.yml
+++ b/.azurepipelines/Platform-Build-GCC5.yml
@@ -109,10 +109,6 @@ jobs:
         BuildTarget: "DEBUG"
         BuildExtraTag: ""
         BuildExtraStep:
-          - script: |
-              sudo apt-get update -qq
-              sudo apt-get install -y libssl-dev clang llvm lld device-tree-compiler
-            displayName: Install openssl
           - script:  |
               git config --global user.name "ado pipline"
               git config --global user.email "placeholderinfo@example.com"
@@ -130,10 +126,6 @@ jobs:
         BuildTarget: "RELEASE"
         BuildExtraTag: ""
         BuildExtraStep:
-          - script: |
-              sudo apt-get update -qq
-              sudo apt-get install -y libssl-dev clang llvm lld device-tree-compiler
-            displayName: Install openssl
           - script:  |
               git config --global user.name "ado pipline"
               git config --global user.email "placeholderinfo@example.com"
@@ -198,10 +190,6 @@ jobs:
         BuildExtraTag: ""
         BuildExtraStep:
           - template: Steps/RustSetupSteps.yml@mu_devops
-          - script: |
-              sudo apt-get update -qq
-              sudo apt-get install -y libssl-dev clang llvm lld device-tree-compiler
-            displayName: Install openssl
           - script:  |
               git config --global user.name "ado pipline"
               git config --global user.email "placeholderinfo@example.com"

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -379,8 +379,10 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         op_fv = os.path.join(self.env.GetValue("BUILD_OUTPUT_BASE"), "FV")
 
         logging.info("Building Hafnium")
+        haf_out = os.path.join(self.env.GetValue("BUILD_OUTPUT_BASE"), "HAF")
         cmd = "make"
         args = "PROJECT=mu PLATFORM=secure_qemu_aarch64"
+        args += " OUT=" + haf_out
         ret = RunCmd(cmd, args, workingdir= self.env.GetValue("ARM_HAF_PATH"))
         if ret != 0:
             return ret
@@ -473,7 +475,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         args += f" SPD=spmd SPMD_SPM_AT_SEL2=1 SP_LAYOUT_FILE={filename}"
         args += " ENABLE_FEAT_HCX=1 HOB_LIST=1 TRANSFER_LIST=1 LOG_LEVEL=40" # Features used by hypervisor
         # args += " FEATURE_DETECTION=1" # Enforces support for features enabled.
-        args += f" BL32={os.path.join(self.env.GetValue('ARM_HAF_PATH'), 'out/mu/secure_qemu_aarch64_clang', 'hafnium.bin')}"
+        args += f" BL32={os.path.join(haf_out, 'secure_qemu_aarch64_clang', 'hafnium.bin')}"
         args += " all fip"
 
         # Third, write a temp bash file to activate the virtual environment and build the firmware.


### PR DESCRIPTION
## Description

This change updates the container that comes with clang, device tree compiler, avoiding the main use case that will require end users to install separately to build TF-A and Hafnium.

In addition, this change fixed the hafnium clean step by moving the output folder to Build folder.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

The new container image was built locally and tested building QEMU SBSA platform. The built image ran successfully.

## Integration Instructions

Pull the latest docker image from mu_devops.
