### PR TITLE
Move test service and inter-partition service to Rust based secure partition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,152 +3,446 @@
 version = 4
 
 [[package]]
-name = "HelloWorldRustDxe"
-version = "0.1.0"
-dependencies = [
- "RustAdvancedLoggerDxe",
- "RustBootServicesAllocatorDxe",
- "r-efi",
-]
-
-[[package]]
-name = "HidIo"
-version = "0.1.0"
-dependencies = [
- "r-efi",
-]
-
-[[package]]
-name = "HiiKeyboardLayout"
-version = "0.1.0"
-dependencies = [
- "num-derive",
- "num-traits",
- "r-efi",
- "scroll",
-]
-
-[[package]]
-name = "RustAdvancedLoggerDxe"
-version = "0.1.0"
-dependencies = [
- "mu_uefi_boot_services",
- "r-efi",
-]
-
-[[package]]
-name = "RustBootServicesAllocatorDxe"
-version = "0.1.0"
-dependencies = [
- "r-efi",
- "spin",
-]
-
-[[package]]
-name = "UefiHidDxe"
-version = "0.1.0"
-dependencies = [
- "HidIo",
- "HiiKeyboardLayout",
- "RustAdvancedLoggerDxe",
- "RustBootServicesAllocatorDxe",
- "hidparser",
- "memoffset",
- "r-efi",
- "rustversion",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.10"
+name = "aarch64-cpu"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "6a21cd0131c25c438e19cd6a774adf7e3f64f7f4d723022882facc2dee0f8bc9"
+dependencies = [
+ "tock-registers",
+]
+
+[[package]]
+name = "aarch64-paging"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a99e1041d545949fa732edf65cab7067ce8f05825c4f6fd4020b70dd76a88df"
+dependencies = [
+ "bitflags",
+ "thiserror",
+]
+
+[[package]]
+name = "aarch64-rt"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be4edaff3b5ead5fb7e9ef0d72fa1e93b4052ec2410e0ebc93f6f360c9599ea"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "ec-service-lib"
+version = "0.1.0"
+dependencies = [
+ "aarch64-cpu",
+ "log",
+ "num_enum",
+ "odp-ffa",
+ "uuid",
+]
+
+[[package]]
+name = "embassy-aarch64-haf"
+version = "0.1.0"
+dependencies = [
+ "aarch64-cpu",
+ "critical-section",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-time",
+ "embassy-time-queue-utils",
+ "hafnium",
+ "log",
+ "odp-ffa",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.7.0"
+source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+dependencies = [
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.6.2"
+source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.1"
+source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+
+[[package]]
+name = "embassy-sync"
+version = "0.7.0"
+source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async",
+ "futures-core",
+ "futures-sink",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.4.0"
+source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.0"
+source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-utils"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+dependencies = [
+ "embassy-executor",
+ "heapless",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
+name = "embedded-hal-async"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
-
-[[package]]
-name = "hidparser"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
- "autocfg",
+ "embedded-hal 1.0.0",
 ]
 
 [[package]]
-name = "mockall"
-version = "0.13.1"
+name = "embedded-io"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
+ "embedded-io",
 ]
 
 [[package]]
-name = "mockall_derive"
-version = "0.13.1"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "hafnium"
+version = "0.1.0"
 dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
+ "aarch64-cpu",
+ "embassy-sync",
+ "log",
 ]
 
 [[package]]
-name = "mu_uefi_boot_services"
-version = "2.0.0"
+name = "hash32"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54a204278942225fa925fb8c416370c94ae83f9100048a7acc2acc5100abcf7"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
- "mockall",
- "r-efi",
+ "byteorder",
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
+name = "heapless"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "hash32",
+ "stable_deref_trait",
 ]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "msft-sp"
+version = "0.0.1"
+dependencies = [
+ "aarch64-cpu",
+ "aarch64-paging",
+ "aarch64-rt",
+ "chrono",
+ "ec-service-lib",
+ "embassy-aarch64-haf",
+ "embassy-executor",
+ "embassy-sync",
+ "hafnium",
+ "log",
+ "odp-ffa",
+ "test-service-lib",
+]
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "num-traits"
@@ -160,54 +454,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "3.1.3"
+name = "num_enum"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
- "anstyle",
- "predicates-core",
+ "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
-name = "predicates-core"
-version = "1.0.9"
+name = "num_enum_derive"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+name = "odp-ffa"
+version = "0.1.0"
 dependencies = [
- "predicates-core",
- "termtree",
+ "log",
+ "num_enum",
+ "uuid",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rustversion"
@@ -216,36 +514,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
-name = "scroll"
-version = "0.11.0"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "scroll_derive"
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -253,13 +543,177 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
+name = "test-service-lib"
+version = "0.1.0"
+dependencies = [
+ "aarch64-cpu",
+ "ec-service-lib",
+ "log",
+ "num_enum",
+ "odp-ffa",
+ "uuid",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tock-registers"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "atomic",
+]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,21 +60,21 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "downcast"
@@ -84,9 +84,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "hidparser"
@@ -187,18 +187,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -211,9 +211,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "scroll"
@@ -243,9 +243,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "2.0.105"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -260,6 +260,6 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,56 +3,66 @@
 version = 4
 
 [[package]]
-name = "aarch64-cpu"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a21cd0131c25c438e19cd6a774adf7e3f64f7f4d723022882facc2dee0f8bc9"
+name = "HelloWorldRustDxe"
+version = "0.1.0"
 dependencies = [
- "tock-registers",
+ "RustAdvancedLoggerDxe",
+ "RustBootServicesAllocatorDxe",
+ "r-efi",
 ]
 
 [[package]]
-name = "aarch64-paging"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a99e1041d545949fa732edf65cab7067ce8f05825c4f6fd4020b70dd76a88df"
+name = "HidIo"
+version = "0.1.0"
 dependencies = [
- "bitflags",
- "thiserror",
+ "r-efi",
 ]
 
 [[package]]
-name = "aarch64-rt"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be4edaff3b5ead5fb7e9ef0d72fa1e93b4052ec2410e0ebc93f6f360c9599ea"
+name = "HiiKeyboardLayout"
+version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "num-derive",
+ "num-traits",
+ "r-efi",
+ "scroll",
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+name = "RustAdvancedLoggerDxe"
+version = "0.1.0"
 dependencies = [
- "libc",
+ "mu_uefi_boot_services",
+ "r-efi",
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+name = "RustBootServicesAllocatorDxe"
+version = "0.1.0"
 dependencies = [
- "bytemuck",
+ "r-efi",
+ "spin",
 ]
+
+[[package]]
+name = "UefiHidDxe"
+version = "0.1.0"
+dependencies = [
+ "HidIo",
+ "HiiKeyboardLayout",
+ "RustAdvancedLoggerDxe",
+ "RustBootServicesAllocatorDxe",
+ "hidparser",
+ "memoffset",
+ "r-efi",
+ "rustversion",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "autocfg"
@@ -61,388 +71,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-
-[[package]]
-name = "bumpalo"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytemuck"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "cc"
-version = "1.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "chrono"
-version = "0.4.41"
+name = "downcast"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
+name = "fragile"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
+name = "hidparser"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 
 [[package]]
-name = "darling"
-version = "0.20.11"
+name = "memoffset"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "autocfg",
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.20.11"
+name = "mockall"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
 ]
 
 [[package]]
-name = "darling_macro"
-version = "0.20.11"
+name = "mockall_derive"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
-dependencies = [
- "litrs",
-]
-
-[[package]]
-name = "ec-service-lib"
-version = "0.1.0"
-dependencies = [
- "aarch64-cpu",
- "log",
- "num_enum",
- "odp-ffa",
- "uuid",
-]
-
-[[package]]
-name = "embassy-aarch64-haf"
-version = "0.1.0"
-dependencies = [
- "aarch64-cpu",
- "critical-section",
- "embassy-executor",
- "embassy-futures",
- "embassy-sync",
- "embassy-time",
- "embassy-time-queue-utils",
- "hafnium",
- "log",
- "odp-ffa",
-]
-
-[[package]]
-name = "embassy-executor"
-version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
-dependencies = [
- "critical-section",
- "document-features",
- "embassy-executor-macros",
-]
-
-[[package]]
-name = "embassy-executor-macros"
-version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
-dependencies = [
- "darling",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "embassy-futures"
-version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
-
-[[package]]
-name = "embassy-sync"
-version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+name = "mu_uefi_boot_services"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54a204278942225fa925fb8c416370c94ae83f9100048a7acc2acc5100abcf7"
 dependencies = [
- "cfg-if",
- "critical-section",
- "embedded-io-async",
- "futures-core",
- "futures-sink",
- "heapless",
+ "mockall",
+ "r-efi",
 ]
 
 [[package]]
-name = "embassy-time"
-version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "cfg-if",
- "critical-section",
- "document-features",
- "embassy-time-driver",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "futures-core",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
-
-[[package]]
-name = "embassy-time-driver"
-version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
-dependencies = [
- "document-features",
-]
-
-[[package]]
-name = "embassy-time-queue-utils"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#dbc4b2bce43ef4ed83458036d1df52f9f79a791d"
-dependencies = [
- "embassy-executor",
- "heapless",
-]
-
-[[package]]
-name = "embedded-hal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
-
-[[package]]
-name = "embedded-hal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
-
-[[package]]
-name = "embedded-hal-async"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
-dependencies = [
- "embedded-hal 1.0.0",
-]
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "embedded-io-async"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
-dependencies = [
- "embedded-io",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "hafnium"
-version = "0.1.0"
-dependencies = [
- "aarch64-cpu",
- "embassy-sync",
- "log",
-]
-
-[[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "js-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.174"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "litrs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-
-[[package]]
-name = "log"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "msft-sp"
-version = "0.0.1"
-dependencies = [
- "aarch64-cpu",
- "aarch64-paging",
- "aarch64-rt",
- "chrono",
- "ec-service-lib",
- "embassy-aarch64-haf",
- "embassy-executor",
- "embassy-sync",
- "hafnium",
- "log",
- "odp-ffa",
- "test-service-lib",
-]
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.1.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "num-traits"
@@ -454,46 +160,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.4"
+name = "predicates"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
- "num_enum_derive",
- "rustversion",
+ "anstyle",
+ "predicates-core",
 ]
 
 [[package]]
-name = "num_enum_derive"
-version = "0.7.4"
+name = "predicates-core"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
-name = "odp-ffa"
-version = "0.1.0"
-dependencies = [
- "log",
- "num_enum",
- "uuid",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "predicates-tree"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -515,65 +211,24 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
+name = "scroll"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "strsim"
+name = "scroll_derive"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "2.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "test-service-lib"
-version = "0.1.0"
-dependencies = [
- "aarch64-cpu",
- "ec-service-lib",
- "log",
- "num_enum",
- "odp-ffa",
- "uuid",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -581,145 +236,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "tock-registers"
-version = "0.9.0"
+name = "spin"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "syn"
+version = "2.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "uuid"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
-dependencies = [
- "atomic",
-]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,7 @@ resolver = "2"
 
 # Add packages that generate binaries here
 members = [
-  "Common/MU/HidPkg/UefiHidDxe",
-  "Common/MU/MsCorePkg/HelloWorldRustDxe"
+  "Features/FFA/FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust",
 ]
 
 # Add packages that generate libraries here
@@ -23,6 +22,37 @@ r-efi = "5.2.0"
 scroll = { version = "0.11", default-features = false, features = ["derive"]}
 rustversion = "1.0.21"
 spin = "0.5.2"
+
+aarch64-cpu = "10.0.0"
+aarch64-paging = { version = "0.8.1", default-features = false }
+aarch64-rt = { version = "0.1.0", default-features = false, features = [
+    "el1",
+    "exceptions",
+] }
+bit-register = { git = "https://github.com/OpenDevicePartnership/odp-utilities", rev = "2f79d238" }
+critical-section = { version = "1.1.0", default-features = false }
+debug-non-default = { git = "https://github.com/OpenDevicePartnership/odp-utilities", rev = "2f79d238" }
+ec-service-lib = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
+embassy-aarch64-haf = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy" }
+embassy-hal-internal = { git = "https://github.com/embassy-rs/embassy" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy" }
+embassy-time-queue-utils = { git = "https://github.com/embassy-rs/embassy" }
+embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
+odp-ffa = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
+hafnium = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
+test-service-lib = { path = "Features/FFA/FfaFeaturePkg/Library/TestServiceLib" }
+user-sp-entry-lib = { path = "Features/FFA/FfaFeaturePkg/Library/SecurePartitionEntryPoint" }
+heapless = "0.8.0"
+log = { version = "0.4", default-features = false }
+mockall = "0.13.1"
+num_enum = { version = "0.7.3", default-features = false }
+subenum = { version = "1.1.2", default-features = false }
+uuid = { version = "1.0", default-features = false, features = ["v1"] }
+rstest = "0.25.0"
 
 # By default, the dev profile is used. The default build settings for the dev profile are documented here:
 # https://doc.rust-lang.org/cargo/reference/profiles.html#dev
@@ -45,3 +75,9 @@ spin = "0.5.2"
 # that needs to be debugged.
 [profile.dev.package."*"]
 opt-level = 3
+
+[patch."https://github.com/OpenDevicePartnership/haf-ec-service"]
+ec-service-lib = { path = "/mnt/d/Repos/haf-ec-service/ec-service-lib" }
+embassy-aarch64-haf = { path = "/mnt/d/Repos/haf-ec-service/embassy-aarch64-haf" }
+odp-ffa = { path = "/mnt/d/Repos/haf-ec-service/odp-ffa" }
+hafnium = { path = "/mnt/d/Repos/haf-ec-service/hafnium" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,37 +23,6 @@ scroll = { version = "0.11", default-features = false, features = ["derive"]}
 rustversion = "1.0.21"
 spin = "0.5.2"
 
-aarch64-cpu = "10.0.0"
-aarch64-paging = { version = "0.8.1", default-features = false }
-aarch64-rt = { version = "0.1.0", default-features = false, features = [
-    "el1",
-    "exceptions",
-] }
-bit-register = { git = "https://github.com/OpenDevicePartnership/odp-utilities", rev = "2f79d238" }
-critical-section = { version = "1.1.0", default-features = false }
-debug-non-default = { git = "https://github.com/OpenDevicePartnership/odp-utilities", rev = "2f79d238" }
-ec-service-lib = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
-embassy-aarch64-haf = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy" }
-embassy-hal-internal = { git = "https://github.com/embassy-rs/embassy" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy" }
-embassy-time-queue-utils = { git = "https://github.com/embassy-rs/embassy" }
-embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
-odp-ffa = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
-hafnium = { git = "https://github.com/OpenDevicePartnership/haf-ec-service" }
-test-service-lib = { path = "Features/FFA/FfaFeaturePkg/Library/TestServiceLib" }
-user-sp-entry-lib = { path = "Features/FFA/FfaFeaturePkg/Library/SecurePartitionEntryPoint" }
-heapless = "0.8.0"
-log = { version = "0.4", default-features = false }
-mockall = "0.13.1"
-num_enum = { version = "0.7.3", default-features = false }
-subenum = { version = "1.1.2", default-features = false }
-uuid = { version = "1.0", default-features = false, features = ["v1"] }
-rstest = "0.25.0"
-
 # By default, the dev profile is used. The default build settings for the dev profile are documented here:
 # https://doc.rust-lang.org/cargo/reference/profiles.html#dev
 #
@@ -75,9 +44,3 @@ rstest = "0.25.0"
 # that needs to be debugged.
 [profile.dev.package."*"]
 opt-level = 3
-
-[patch."https://github.com/OpenDevicePartnership/haf-ec-service"]
-ec-service-lib = { path = "/mnt/d/Repos/haf-ec-service/ec-service-lib" }
-embassy-aarch64-haf = { path = "/mnt/d/Repos/haf-ec-service/embassy-aarch64-haf" }
-odp-ffa = { path = "/mnt/d/Repos/haf-ec-service/odp-ffa" }
-hafnium = { path = "/mnt/d/Repos/haf-ec-service/hafnium" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ resolver = "2"
 
 # Add packages that generate binaries here
 members = [
-  "Features/FFA/FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust",
+  "Common/MU/HidPkg/UefiHidDxe",
+  "Common/MU/MsCorePkg/HelloWorldRustDxe"
 ]
 
 # Add packages that generate libraries here

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -432,8 +432,8 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
                 },
                 "mssp": {
                     "image": {
-                        "file": os.path.join(self.env.GetValue('BUILD_OUTPUT_BASE'), 'FV', 'BL32_AP_MM_SP1.fd'),
-                        "offset": "0x10000"
+                        "file": os.path.join(self.GetWorkspaceRoot(), 'target/aarch64-unknown-none/debug/msft-sp.bin'),
+                        "offset": "0x2000"
                     },
                     "pm": {
                         "file": os.path.join(os.path.dirname(__file__), "fdts/qemu_sbsa_mssp_config.dts"),

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -394,8 +394,10 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
             return ret
 
         logging.info("Building Hafnium")
+        haf_out = os.path.join(self.env.GetValue("BUILD_OUTPUT_BASE"), "HAF")
         cmd = "make"
         args = "PROJECT=mu PLATFORM=secure_qemu_aarch64"
+        args += " OUT=" + haf_out
         ret = RunCmd(cmd, args, workingdir= self.env.GetValue("ARM_HAF_PATH"))
         if ret != 0:
             return ret
@@ -500,7 +502,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         args += f" SPD=spmd SPMD_SPM_AT_SEL2=1 SP_LAYOUT_FILE={filename}"
         args += " ENABLE_FEAT_HCX=1 HOB_LIST=1 TRANSFER_LIST=1 LOG_LEVEL=40" # Features used by hypervisor
         # args += " FEATURE_DETECTION=1" # Enforces support for features enabled.
-        args += f" BL32={os.path.join(self.env.GetValue('ARM_HAF_PATH'), 'out/mu/secure_qemu_aarch64_clang', 'hafnium.bin')}"
+        args += f" BL32={os.path.join(haf_out, 'secure_qemu_aarch64_clang', 'hafnium.bin')}"
         args += " all fip"
 
         # Third, write a temp bash file to activate the virtual environment and build the firmware.

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -514,7 +514,6 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
         # Grab the current head to restore from patches later.
         patch_tfa = (self.env.GetValue("PATCH_TFA", "TRUE").upper() == "TRUE")
-        patch_tfa = False
         if patch_tfa:
             outstream = StringIO()
             ret = RunCmd("git", "rev-parse HEAD", outstream=outstream, workingdir=self.env.GetValue("ARM_TFA_PATH"))

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1454,6 +1454,7 @@
   FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.inf
 
   # Test secure partition
+  # FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/MsSecurePartitionRust.inf
   FfaFeaturePkg/SecurePartitions/MsSecurePartition/MsSecurePartition.inf {
     <LibraryClasses>
       NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -172,10 +172,6 @@
   ArmFfaLibEx|FfaFeaturePkg/Library/ArmFfaLibEx/ArmFfaLibEx.inf
   PlatformFfaInterruptLib|FfaFeaturePkg/Library/PlatformFfaInterruptLibNull/PlatformFfaInterruptLib.inf
 
-  # Secure Partition Services
-  NotificationServiceLib|FfaFeaturePkg/Library/NotificationServiceLib/NotificationServiceLib.inf
-  TestServiceLib|FfaFeaturePkg/Library/TestServiceLib/TestServiceLib.inf
-
   #
   # Uncomment (and comment out the next line) For RealView Debugger. The Standard IO window
   # in the debugger will show load and unload commands for symbols. You can cut and paste this
@@ -1454,7 +1450,6 @@
   FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.inf
 
   # Test secure partition
-  # FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/MsSecurePartitionRust.inf
   FfaFeaturePkg/SecurePartitions/MsSecurePartition/MsSecurePartition.inf {
     <LibraryClasses>
       NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -31,9 +31,9 @@ DEFINE FVMAIN_COMPACT_SIZE  = 0x2ff000
   DEFINE SECURE_FLASH_REGION_BL1_SIZE                                 = 0x00012000
 #===================================================================================
   DEFINE SECURE_FLASH_REGION_FIP_OFFSET                               = 0x00012000
-  DEFINE SECURE_FLASH_REGION_FIP_SIZE                                 = 0x00300000
+  DEFINE SECURE_FLASH_REGION_FIP_SIZE                                 = 0x003EE000
 #===================================================================================
-  # Unused bytes offset                                                 0x00312000
+  # Unused bytes offset                                                 0x00400000
   # Unused bytes size                                                   0x00CEE000
 #===================================================================================
   DEFINE SECURE_FLASH_NVSTORAGE_OFFSET                                = 0x01000000
@@ -154,15 +154,15 @@ gArmTokenSpaceGuid.PcdFvBaseAddress|gArmTokenSpaceGuid.PcdFvSize
 FV = FV_STANDALONE_MM_COMPACT
 
 [FD.BL32_AP_MM_SP1]
-BaseAddress   = 0x20410000|gArmTokenSpaceGuid.PcdFdBaseAddress  # UEFI in DRAM + 128MB.
-Size          = 0x00014000|gArmTokenSpaceGuid.PcdFdSize         # The size in bytes of the device (64MiB).
+BaseAddress   = 0x20400000|gArmTokenSpaceGuid.PcdFdBaseAddress  # UEFI in DRAM + 128MB.
+Size          = 0x00060000|gArmTokenSpaceGuid.PcdFdSize         # The size in bytes of the device (64MiB).
 ErasePolarity = 1
 
 BlockSize     = 0x00001000
-NumBlocks     = 0x00014
+NumBlocks     = 0x00060
 
-0x00000000|0x00014000
-FV = FV_STANDALONE_MM_SECURE_PARTITION1
+0x00000000|0x00060000
+# Placeholder only
 
 [FD.QEMU_EFI]
 BaseAddress   = 0x10000000|gArmTokenSpaceGuid.PcdFdBaseAddress
@@ -553,25 +553,26 @@ READ_LOCK_STATUS   = TRUE
   INF QemuSbsaPkg/VirtNorFlashStandaloneMm/VirtNorFlashStandaloneMm.inf
   INF ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
 
-[FV.FV_STANDALONE_MM_SECURE_PARTITION1]
-FvAlignment        = 16
-ERASE_POLARITY     = 1
-MEMORY_MAPPED      = TRUE
-STICKY_WRITE       = TRUE
-LOCK_CAP           = TRUE
-LOCK_STATUS        = TRUE
-WRITE_DISABLED_CAP = TRUE
-WRITE_ENABLED_CAP  = TRUE
-WRITE_STATUS       = TRUE
-WRITE_LOCK_CAP     = TRUE
-WRITE_LOCK_STATUS  = TRUE
-READ_DISABLED_CAP  = TRUE
-READ_ENABLED_CAP   = TRUE
-READ_STATUS        = TRUE
-READ_LOCK_CAP      = TRUE
-READ_LOCK_STATUS   = TRUE
+# [FV.FV_STANDALONE_MM_SECURE_PARTITION1]
+# FvAlignment        = 16
+# ERASE_POLARITY     = 1
+# MEMORY_MAPPED      = TRUE
+# STICKY_WRITE       = TRUE
+# LOCK_CAP           = TRUE
+# LOCK_STATUS        = TRUE
+# WRITE_DISABLED_CAP = TRUE
+# WRITE_ENABLED_CAP  = TRUE
+# WRITE_STATUS       = TRUE
+# WRITE_LOCK_CAP     = TRUE
+# WRITE_LOCK_STATUS  = TRUE
+# READ_DISABLED_CAP  = TRUE
+# READ_ENABLED_CAP   = TRUE
+# READ_STATUS        = TRUE
+# READ_LOCK_CAP      = TRUE
+# READ_LOCK_STATUS   = TRUE
 
-  INF FfaFeaturePkg/SecurePartitions/MsSecurePartition/MsSecurePartition.inf
+#   INF FfaFeaturePkg/SecurePartitions/MsSecurePartition/MsSecurePartition.inf
+#   INF FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/MsSecurePartitionRust.inf
 
 ################################################################################
 #

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -31,10 +31,10 @@ DEFINE FVMAIN_COMPACT_SIZE  = 0x2ff000
   DEFINE SECURE_FLASH_REGION_BL1_SIZE                                 = 0x00012000
 #===================================================================================
   DEFINE SECURE_FLASH_REGION_FIP_OFFSET                               = 0x00012000
-  DEFINE SECURE_FLASH_REGION_FIP_SIZE                                 = 0x003EE000
+  DEFINE SECURE_FLASH_REGION_FIP_SIZE                                 = 0x009EE000
 #===================================================================================
-  # Unused bytes offset                                                 0x00400000
-  # Unused bytes size                                                   0x00CEE000
+  # Unused bytes offset                                                 0x00A00000
+  # Unused bytes size                                                   0x005EE000
 #===================================================================================
   DEFINE SECURE_FLASH_NVSTORAGE_OFFSET                                = 0x01000000
   DEFINE SECURE_FLASH_NVSTORAGE_SIZE                                  = 0x000C0000
@@ -153,15 +153,26 @@ NumBlocks     = 0x0e00
 gArmTokenSpaceGuid.PcdFvBaseAddress|gArmTokenSpaceGuid.PcdFvSize
 FV = FV_STANDALONE_MM_COMPACT
 
-[FD.BL32_AP_MM_SP1]
-BaseAddress   = 0x20400000|gArmTokenSpaceGuid.PcdFdBaseAddress  # UEFI in DRAM + 128MB.
-Size          = 0x00060000|gArmTokenSpaceGuid.PcdFdSize         # The size in bytes of the device (64MiB).
+[FD.BL32_AP_MS_SP]
+BaseAddress   = 0x20410000|gArmTokenSpaceGuid.PcdFdBaseAddress  # UEFI in DRAM + 128MB.
+Size          = 0x003F0000|gArmTokenSpaceGuid.PcdFdSize         # The size in bytes of the device (64MiB).
 ErasePolarity = 1
 
 BlockSize     = 0x00001000
-NumBlocks     = 0x00060
+NumBlocks     = 0x003F0
 
-0x00000000|0x00060000
+0x00000000|0x003F0000
+FV = FV_MS_SECURE_PARTITION
+
+[FD.BL32_AP_MS_SP_RUST]
+BaseAddress   = 0x20800000|gArmTokenSpaceGuid.PcdFdBaseAddress  # UEFI in DRAM + 128MB.
+Size          = 0x00400000|gArmTokenSpaceGuid.PcdFdSize         # The size in bytes of the device (64MiB).
+ErasePolarity = 1
+
+BlockSize     = 0x00001000
+NumBlocks     = 0x00400
+
+0x00000000|0x00400000
 # Placeholder only
 
 [FD.QEMU_EFI]
@@ -518,7 +529,6 @@ READ_LOCK_STATUS   = TRUE
 
 !if $(TPM2_ENABLE) == TRUE
   INF MdeModulePkg/Universal/ResetSystemPei/ResetSystemPei.inf
-  INF QemuPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
   INF SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
 !endif
 
@@ -553,26 +563,25 @@ READ_LOCK_STATUS   = TRUE
   INF QemuSbsaPkg/VirtNorFlashStandaloneMm/VirtNorFlashStandaloneMm.inf
   INF ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
 
-# [FV.FV_STANDALONE_MM_SECURE_PARTITION1]
-# FvAlignment        = 16
-# ERASE_POLARITY     = 1
-# MEMORY_MAPPED      = TRUE
-# STICKY_WRITE       = TRUE
-# LOCK_CAP           = TRUE
-# LOCK_STATUS        = TRUE
-# WRITE_DISABLED_CAP = TRUE
-# WRITE_ENABLED_CAP  = TRUE
-# WRITE_STATUS       = TRUE
-# WRITE_LOCK_CAP     = TRUE
-# WRITE_LOCK_STATUS  = TRUE
-# READ_DISABLED_CAP  = TRUE
-# READ_ENABLED_CAP   = TRUE
-# READ_STATUS        = TRUE
-# READ_LOCK_CAP      = TRUE
-# READ_LOCK_STATUS   = TRUE
+[FV.FV_MS_SECURE_PARTITION]
+FvAlignment        = 16
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
 
-#   INF FfaFeaturePkg/SecurePartitions/MsSecurePartition/MsSecurePartition.inf
-#   INF FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/MsSecurePartitionRust.inf
+  INF FfaFeaturePkg/SecurePartitions/MsSecurePartition/MsSecurePartition.inf
 
 ################################################################################
 #

--- a/Platforms/QemuSbsaPkg/fdts/qemu_sbsa_mssp_config.dts
+++ b/Platforms/QemuSbsaPkg/fdts/qemu_sbsa_mssp_config.dts
@@ -30,10 +30,10 @@
 	uuid = <0x7ed874e4 0x44403157 0x3ecb27a7 0xdfc8f38c>, <0xa462b817 0xaf4f0618 0x9a08b386 0x61383558>, <0xb3d9fae0 0xc5425c7f 0xa8b7eeb2 0xb2cd1323>;
 	id = <0x8002>;
 	execution-ctx-count = <1>;
-	exception-level = <1>; /* SEL0*/
+	exception-level = <2>; /* SEL0*/
 	execution-state = <0>; /* AArch64*/
 	load-address = <0x0 0x20400000>;
-	entrypoint-offset = <0x10000>;
+	entrypoint-offset = <0x2000>;
 	image-size = <0x0 0x400000>;
 	xlat-granule = <0>; /* 4KiB */
 	boot-order = <1>;
@@ -45,6 +45,32 @@
 	boot-info {
 		compatible = "arm,ffa-manifest-boot-info";
 		ffa_manifest;
+	};
+
+	memory-regions {
+		compatible = "arm,ffa-manifest-memory-regions";
+
+		/*
+		 * Memory shared between EL3 and S-EL0.
+		 * Similar to ARM_SPM_BUF_EL0_MMAP.
+		 */
+		rx-tx-buffers {
+			description = "shared-buff";
+			base-address = <0x100 0x600A0000>;
+			pages-count = <0x2>;
+			attributes = <0x3>;
+		};
+
+		/*
+		 * Memory shared between S-EL0 and NS-EL1.
+		 * Similar to ARM_SPM_BUF_NS_MMAP.
+		 */
+		smem-buffers {
+			description = "smem-buff";
+			base-address = <0x100 0x60000000>;
+			pages-count = <0x2>;
+			attributes = <0x3>;
+		};
 	};
 
 	device-regions {

--- a/Platforms/QemuSbsaPkg/fdts/qemu_sbsa_mssp_rust_config.dts
+++ b/Platforms/QemuSbsaPkg/fdts/qemu_sbsa_mssp_rust_config.dts
@@ -21,22 +21,22 @@
 	/*
 	 * FF-A compatible Secure Partition Manager parses the
 	 * config file and fetch the following booting arguments to
-	 * pass on to the  Secure Partition.
+	 * pass on to the Secure Partition.
 	 */
 	compatible = "arm,ffa-manifest-1.0";
 
 	description = "Microsoft Services";
 	ffa-version = <0x00010002>; /* 31:16 - Major, 15:0 - Minor */
-	uuid = <0xa462b817 0xaf4f0618 0x9a08b386 0x61383558>;
-	id = <0x8002>;
+	uuid = <0x7ed874e4 0x44403157 0x3ecb27a7 0xdfc8f38c>, <0xb3d9fae0 0xc5425c7f 0xa8b7eeb2 0xb2cd1323>;
+	id = <0x8003>;
 	execution-ctx-count = <1>;
-	exception-level = <1>; /* SEL0*/
+	exception-level = <2>; /* SEL1*/
 	execution-state = <0>; /* AArch64*/
-	load-address = <0x0 0x20400000>;
-	entrypoint-offset = <0x10000>;
+	load-address = <0x0 0x20800000>;
+	entrypoint-offset = <0x2000>;
 	image-size = <0x0 0x400000>;
 	xlat-granule = <0>; /* 4KiB */
-	boot-order = <1>;
+	boot-order = <2>;
 	messaging-method = <0x603>; /* Direct request/response supported. */
 	ns-interrupts-action = <0>; /* Non-secure interrupt is queued */
 	notification-support; /* Support receipt of notifications. */
@@ -47,29 +47,28 @@
 		ffa_manifest;
 	};
 
-	device-regions {
-		compatible = "arm,ffa-manifest-device-regions";
+	memory-regions {
+		compatible = "arm,ffa-manifest-memory-regions";
 
 		/*
-		 * Secure UART region.
+		 * Memory shared between EL3 and S-EL0.
+		 * Similar to ARM_SPM_BUF_EL0_MMAP.
 		 */
-		secure_uart {
-			base-address = <0x0 0x60030000>;
-			pages-count = <0x1>;
+		rx-tx-buffers {
+			description = "shared-buff";
+			base-address = <0x100 0x600A0000>;
+			pages-count = <0x2>;
 			attributes = <0x3>;
 		};
 
-		internal_tpm_crb {
-			description = "internal tpm crb";
-			base-address = <0x00000100 0x00200000>;
-			pages-count = <0x10>;
-			attributes = <0x3>;
-		};
-
-		external_tpm_crb {
-			description = "external tpm crb";
-			base-address = <0x00000000 0x60120000>;
-			pages-count = <0x10>;
+		/*
+		 * Memory shared between S-EL0 and NS-EL1.
+		 * Similar to ARM_SPM_BUF_NS_MMAP.
+		 */
+		smem-buffers {
+			description = "smem-buff";
+			base-address = <0x100 0x60000000>;
+			pages-count = <0x2>;
 			attributes = <0x3>;
 		};
 	};

--- a/Platforms/QemuSbsaPkg/tfa_patches/0001-Changes-needed-to-hack-through-QEMU-SBSA-usage.patch
+++ b/Platforms/QemuSbsaPkg/tfa_patches/0001-Changes-needed-to-hack-through-QEMU-SBSA-usage.patch
@@ -1,4 +1,4 @@
-From c9537c20b8cda91c8214be04b842695321199d68 Mon Sep 17 00:00:00 2001
+From db11014190a055bf7d20dd004b575c527bc36ece Mon Sep 17 00:00:00 2001
 From: Kun Qin <kuqin@microsoft.com>
 Date: Thu, 31 Oct 2024 00:41:05 -0700
 Subject: [PATCH 1/2] Changes needed to hack through QEMU SBSA usage
@@ -11,20 +11,20 @@ Co-authored-by: rdiaz <raymonddiaz@microsoft.com>
 
 Updated DTS files to include the correct UUID for the Notification SP and added the device regions for the TPM CRBs
 ---
- .../fdts/qemu_sbsa_spmc_sp_manifest.dts       | 118 ++++++++++++++++++
- .../qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts |  42 +++++++
- plat/qemu/qemu_sbsa/include/platform_def.h    |  35 ++++--
- plat/qemu/qemu_sbsa/platform.mk               |  21 ++++
- 4 files changed, 209 insertions(+), 7 deletions(-)
+ .../fdts/qemu_sbsa_spmc_sp_manifest.dts       | 136 ++++++++++++++++++
+ .../qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts |  47 ++++++
+ plat/qemu/qemu_sbsa/include/platform_def.h    |  35 ++++-
+ plat/qemu/qemu_sbsa/platform.mk               |  21 +++
+ 4 files changed, 232 insertions(+), 7 deletions(-)
  create mode 100644 plat/qemu/qemu_sbsa/fdts/qemu_sbsa_spmc_sp_manifest.dts
  create mode 100644 plat/qemu/qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts
 
 diff --git a/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_spmc_sp_manifest.dts b/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_spmc_sp_manifest.dts
 new file mode 100644
-index 000000000..3c0187cfa
+index 000000000..69b24a68f
 --- /dev/null
 +++ b/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_spmc_sp_manifest.dts
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,136 @@
 +/*
 + * Copyright (c) 2022, Arm Limited. All rights reserved.
 + *
@@ -67,7 +67,15 @@ index 000000000..3c0187cfa
 +     vm2 {
 +       is_ffa_partition;
 +       load_address = <0x0 0x20400000>;
-+       debug_name = "therm";
++       debug_name = "mssp";
++       vcpu_count = <1>;
++       mem_size = <0x400000>;
++     };
++     /* Example Rust Service */
++     vm3 {
++       is_ffa_partition;
++       load_address = <0x0 0x20800000>;
++       debug_name = "mssp-rust";
 +       vcpu_count = <1>;
 +       mem_size = <0x400000>;
 +     };
@@ -155,10 +163,10 @@ index 000000000..3c0187cfa
 +};
 diff --git a/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts b/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts
 new file mode 100644
-index 000000000..1e9284248
+index 000000000..5b655c37a
 --- /dev/null
 +++ b/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,47 @@
 +/*
 + * Copyright (c) 2022, ARM Limited and Contributors. All rights reserved.
 + *
@@ -199,10 +207,15 @@ index 000000000..1e9284248
 +      load-address = <0x20400000>;
 +      owner = "Plat";
 +    };
++    example_rust {
++      uuid = "AFF0C73B-47E7-4A5B-AFFC-0052305A6520";
++      load-address = <0x20800000>;
++      owner = "Plat";
++    };
 +   };
 + };
 diff --git a/plat/qemu/qemu_sbsa/include/platform_def.h b/plat/qemu/qemu_sbsa/include/platform_def.h
-index 9979fe11e..d9b210bdf 100644
+index 85bd233d4..b0282a077 100644
 --- a/plat/qemu/qemu_sbsa/include/platform_def.h
 +++ b/plat/qemu/qemu_sbsa/include/platform_def.h
 @@ -148,11 +148,33 @@
@@ -214,7 +227,7 @@ index 9979fe11e..d9b210bdf 100644
  #define BL31_BASE			(BL31_LIMIT - BL31_SIZE)
  #define BL31_LIMIT			(BL1_RW_BASE - FW_HANDOFF_SIZE)
  #define BL31_PROGBITS_LIMIT		BL1_RW_BASE
-
+ 
 +/*
 + * Configuration defines.
 + *
@@ -246,7 +259,7 @@ index 9979fe11e..d9b210bdf 100644
  #define BL32_SRAM_BASE			BL_RAM_BASE
 -#define BL32_SRAM_LIMIT			BL2_BASE
 +#define BL32_SRAM_LIMIT			SPMD_BASE
-
+ 
 -#define BL32_MEM_BASE			BL_RAM_BASE
 -#define BL32_MEM_SIZE			(BL_RAM_SIZE - RME_GPT_DRAM_SIZE - \
 -					BL1_SIZE - BL2_SIZE - BL31_SIZE)
@@ -256,7 +269,7 @@ index 9979fe11e..d9b210bdf 100644
 +#define BL32_MEM_SIZE			(SPMD_LIMIT - SPMD_BASE)
 +#define BL32_BASE					SPMD_BASE
 +#define BL32_LIMIT			  SPMD_LIMIT
-
+ 
  #define NS_IMAGE_OFFSET			(NS_DRAM0_BASE + 0x20000000)
  #define NS_IMAGE_MAX_SIZE		(NS_DRAM0_SIZE - 0x20000000)
 diff --git a/plat/qemu/qemu_sbsa/platform.mk b/plat/qemu/qemu_sbsa/platform.mk
@@ -266,7 +279,7 @@ index 8ec3a8249..d3ef3dda7 100644
 @@ -29,6 +29,13 @@ ifeq ($(NEED_BL32),yes)
  $(eval $(call add_define,QEMU_LOAD_BL32))
  endif
-
+ 
 +ifeq (${SPMD_SPM_AT_SEL2}, 1)
 +FDT_SOURCES		+=  ${PLAT_QEMU_PATH}/fdts/${PLAT}_tb_fw_config.dts
 +BL32_CONFIG_DTS		:=	${PLAT_QEMU_PATH}/fdts/${PLAT}_spmc_sp_manifest.dts
@@ -276,11 +289,11 @@ index 8ec3a8249..d3ef3dda7 100644
 +
  # Include GICv3 driver files
  include drivers/arm/gic/v3/gicv3.mk
-
+ 
 @@ -47,6 +54,20 @@ ifeq (${SPM_MM},1)
  	BL31_SOURCES		+=	${PLAT_QEMU_COMMON_PATH}/qemu_spm.c
  endif
-
+ 
 +ifeq (${SPMD_SPM_AT_SEL2}, 1)
 +BL1_SOURCES += plat/common/plat_spmd_manifest.c
 +
@@ -298,6 +311,6 @@ index 8ec3a8249..d3ef3dda7 100644
  # Use known base for UEFI if not given from command line
  # By default BL33 is at FLASH1 base
  PRELOADED_BL33_BASE	?= 0x10000000
---
-2.34.1
+-- 
+2.43.0
 

--- a/Platforms/QemuSbsaPkg/tfa_patches/0001-Changes-needed-to-hack-through-QEMU-SBSA-usage.patch
+++ b/Platforms/QemuSbsaPkg/tfa_patches/0001-Changes-needed-to-hack-through-QEMU-SBSA-usage.patch
@@ -142,6 +142,16 @@ index 000000000..3c0187cfa
 +    device_type = "device-memory"; /* External CRB */
 +    reg = <0x00000000 0x60120000 0x0 0x00010000>;
 +  };
++
++  memory@10 {
++    device_type = "memory"; /* External CRB */
++    reg = <0x00000100 0x60000000 0x0 0x00002000>;
++  };
++
++  memory@11 {
++    device_type = "memory"; /* External CRB */
++    reg = <0x00000100 0x600A0000 0x0 0x00002000>;
++  };
 +};
 diff --git a/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts b/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_tb_fw_config.dts
 new file mode 100644

--- a/Platforms/QemuSbsaPkg/tfa_patches/0002-Fixing-SBSA-MP-usage-4.patch
+++ b/Platforms/QemuSbsaPkg/tfa_patches/0002-Fixing-SBSA-MP-usage-4.patch
@@ -1,4 +1,4 @@
-From fc07528c7fb7a4b54f304a02cc8a3ea884ee319f Mon Sep 17 00:00:00 2001
+From 6f00302e3f2f18ebfbad5664bc7de1758b31ec18 Mon Sep 17 00:00:00 2001
 From: kuqin12 <42554914+kuqin12@users.noreply.github.com>
 Date: Mon, 13 Jan 2025 12:05:21 -0800
 Subject: [PATCH 2/2] Fixing SBSA MP usage (#4)
@@ -170,10 +170,10 @@ index 000000000..99fc9b2ee
 +endfunc plat_crash_console_flush
 +
 diff --git a/plat/qemu/common/common.mk b/plat/qemu/common/common.mk
-index 2dc89bccb..c539046d5 100644
+index 751511cf8..e3fa216fb 100644
 --- a/plat/qemu/common/common.mk
 +++ b/plat/qemu/common/common.mk
-@@ -50,7 +50,7 @@ BL1_SOURCES		+=	drivers/io/io_semihosting.c		\
+@@ -49,7 +49,7 @@ BL1_SOURCES		+=	drivers/io/io_semihosting.c		\
  				lib/semihosting/semihosting.c		\
  				lib/semihosting/${ARCH}/semihosting_call.S	\
  				${PLAT_QEMU_COMMON_PATH}/qemu_io_storage.c	\
@@ -181,23 +181,23 @@ index 2dc89bccb..c539046d5 100644
 +				${PLAT_QEMU_COMMON_PATH}/${ARCH}/plat_helpers_bl1.S	\
  				${PLAT_QEMU_COMMON_PATH}/qemu_bl1_setup.c	\
  				${QEMU_CPU_LIBS}
-
+ 
 diff --git a/plat/qemu/common/qemu_bl31_setup.c b/plat/qemu/common/qemu_bl31_setup.c
-index 81ce1023a..b5162b597 100644
+index 1c5e0eaf7..0f2b7193b 100644
 --- a/plat/qemu/common/qemu_bl31_setup.c
 +++ b/plat/qemu/common/qemu_bl31_setup.c
-@@ -56,6 +56,7 @@ static entry_point_info_t bl33_image_ep_info;
+@@ -80,6 +80,7 @@ static entry_point_info_t bl33_image_ep_info;
  static entry_point_info_t rmm_image_ep_info;
  #endif
  static struct transfer_list_header *bl31_tl;
 +void __dead2 plat_secondary_cold_boot_setup(void);
-
+ 
  /*******************************************************************************
   * Perform any BL3-1 early platform setup.  Here is an opportunity to copy
-@@ -90,6 +91,11 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
-
+@@ -114,6 +115,11 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+ 
  	bl_params_node_t *bl_params = params_from_bl2->head;
-
+ 
 +	// We hacked the bl1 function to wait for any signal like this...
 +	// Should not be used in production
 +	uintptr_t *mailbox = (uintptr_t *)PLAT_QEMU_TRUSTED_MAILBOX_BASE;
@@ -207,7 +207,7 @@ index 81ce1023a..b5162b597 100644
  	 * Copy BL33, BL32 and RMM (if present), entry point information.
  	 * They are stored in Secure RAM, in BL2's address space.
 diff --git a/plat/qemu/qemu_sbsa/sbsa_pm.c b/plat/qemu/qemu_sbsa/sbsa_pm.c
-index 8d1e1d48c..fb1bb4330 100644
+index 7ce7beba9..a75c0a63a 100644
 --- a/plat/qemu/qemu_sbsa/sbsa_pm.c
 +++ b/plat/qemu/qemu_sbsa/sbsa_pm.c
 @@ -170,7 +170,7 @@ qemu_pwr_domain_pwr_down_wfi(const psci_power_state_t *target_state)
@@ -217,7 +217,7 @@ index 8d1e1d48c..fb1bb4330 100644
 -	assert(false);
 +	// assert(false);
  }
-
+ 
  /*******************************************************************************
 @@ -193,7 +193,7 @@ void qemu_pwr_domain_on_finish(const psci_power_state_t *target_state)
   ******************************************************************************/
@@ -226,7 +226,7 @@ index 8d1e1d48c..fb1bb4330 100644
 -	assert(false);
 +	// assert(false);
  }
-
+ 
  /*******************************************************************************
 @@ -208,6 +208,11 @@ static void __dead2 qemu_system_off(void)
  static void __dead2 qemu_system_reset(void)
@@ -239,7 +239,7 @@ index 8d1e1d48c..fb1bb4330 100644
 +
  	panic();
  }
-
---
-2.34.1
+ 
+-- 
+2.43.0
 


### PR DESCRIPTION
## Description

FF-A feature repo recently integrated the rust based secure partition. This change is made to integrate the platform to consume updated secure partitions.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on SBSA platform and passed the FF-A test application.

## Integration Instructions

N/A
