### PR TITLE
Disable SVE/SME on QemuSbsaPkg

### DIFF
--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -477,7 +477,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         args += " PLAT=" + self.env.GetValue("QEMU_PLATFORM").lower()
         args += " ARCH=" + self.env.GetValue("TARGET_ARCH").lower()
         args += " DEBUG=" + str(1 if self.env.GetValue("TARGET").lower() == 'debug' else 0)
-        args += " ENABLE_SME_FOR_SWD=1 ENABLE_SVE_FOR_SWD=1 ENABLE_SME_FOR_NS=1 ENABLE_SVE_FOR_NS=1"
+        args += " ENABLE_SME_FOR_SWD=0 ENABLE_SVE_FOR_SWD=0 ENABLE_SME_FOR_NS=0 ENABLE_SVE_FOR_NS=0"
         args += f" SPD=spmd SPMD_SPM_AT_SEL2=1 SP_LAYOUT_FILE={filename}"
         args += " ENABLE_FEAT_HCX=1 HOB_LIST=1 TRANSFER_LIST=1 LOG_LEVEL=40" # Features used by hypervisor
         # args += " FEATURE_DETECTION=1" # Enforces support for features enabled.

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -116,7 +116,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += " -m 2048"
 
         args += " -machine sbsa-ref" #,accel=(tcg|kvm)"
-        args += " -cpu max"
+        args += " -cpu max,sve=off,sme=off"
         if env.GetBuildValue ("QEMU_CORE_NUM") is not None:
           args += " -smp " + env.GetBuildValue ("QEMU_CORE_NUM")
         args += " -global driver=cfi.pflash01,property=secure,value=on"


### PR DESCRIPTION
## Description

When FF-A support was added to QemuSbsaPkg, it re-enabled SVE and SME for TF-A and QEMU, which had been disabled because Windows boot was broken with those.

Windows boot is again broken because of SVE/SME and a [change in ArmPlatformPkg](https://github.com/microsoft/mu_silicon_arm_tiano/commit/cb87aada970c68c1a210ed68a4a1ce238623e3c3) consumed from edk2 that aligned the feature register reserved field behavior with the spec. A Windows change will be forthcoming, but in the mean time, SVE/SME needs to be disabled again. The edk2 change is technically correct, so that change is left in place.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting SBSA to Windows was failing; now it is succeeding.

## Integration Instructions

Rebuild TF-A with the PlatformBuild.py changes, boot qemu with the changes in QemuRunner.py.
