### PR TITLE
Add key interrupt so that it will reset the console mode

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -244,7 +244,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         try:
             ret = utility_functions.RunCmd(executable, args)
         except KeyboardInterrupt:
-            logging.critical("QEMU run interrupted.")
+            logging.critical("QEMU run interrupted by user (ctrl+c).")
             ret = -1
 
         ## TODO: restore the customized RunCmd once unit tests with asserts are figured out


### PR DESCRIPTION
## Description

If QEMU is interrupted with `Ctrl + C`, the QEMU will leave the odd console mode enabled.

There used to be some logic handling the console mode restoration, but that did not work with key interrupt case.

This change is updated to fix that case.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified that QEMU interrupted by keyboard no longer has odd console mode after the change.

## Integration Instructions

N/A