### PR TITLE
Fix permissions for build-haf-tfa.yml

### DIFF
--- a/.github/workflows/build-haf-tfa.yml
+++ b/.github/workflows/build-haf-tfa.yml
@@ -27,6 +27,14 @@ jobs:
       image: ghcr.io/microsoft/mu_devops/ubuntu-24-dev:latest
 
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MU_ACCESS_APP_ID }}
+          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout Code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

Fix permissions for build-haf-tfa.yml

Fixes an issue where the release assets would fail to upload.

`HTTP 403: Resource not accessible by integration (https://uploads.github.com/repos/microsoft/mu_tiano_platforms/releases/261590859/assets?label=&name=haf-tfa-firmware-v11.0.0.zip)`

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on my fork by disabling Read and Write Permissions for Workflows on my fork. It was set to Read and Write by default. Changed to only Read permissions then performed the following test:

Tested the workflow on a test release to make sure it fails the upload step. Failing run: https://github.com/eeshanl/mu_tiano_platforms/actions/runs/20293867580/job/58283434736

Then tested again with this PR's commit by adding the Generate Token step to the yml and the test succeeded.
https://github.com/microsoft/mu_tiano_platforms/actions/runs/20312966615/job/58348972808

Real test will be in main.

## Integration Instructions

N/A