### PR TITLE
Fix file upload error via permissions

### DIFF
--- a/.github/workflows/build-haf-tfa.yml
+++ b/.github/workflows/build-haf-tfa.yml
@@ -25,16 +25,10 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/microsoft/mu_devops/ubuntu-24-dev:latest
+    permissions:
+      contents: write
 
     steps:
-      - name: Generate Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.MU_ACCESS_APP_ID }}
-          private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout Code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

Switch to using permissions: block instead of generating github app token 

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on my fork with Read only permissions set.

## Integration Instructions

N/A
