### PR TITLE
.github: Use the GitHub app token to upload release assets

### DIFF
--- a/.github/workflows/build-haf-tfa.yml
+++ b/.github/workflows/build-haf-tfa.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Upload Release Assets
         if: github.event_name == 'release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release upload "${{ github.event.release.tag_name }}" "${RUNNER_TEMP}"/*.zip
           gh release upload "${{ github.event.release.tag_name }}" "${RUNNER_TEMP}"/*.tar.gz


### PR DESCRIPTION
## Description

Commit 75d168f did not update the upload step to use the app derived token.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified app permissions. Will test with release post-merge.

## Integration Instructions

- N/A