### PR TITLE
QemuQ35 Acceleration

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
+++ b/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
@@ -699,6 +699,11 @@
   # a PCD that controls the enumeration and connection of ConIn's. When true, ConIn is only connected once a console input is requests
   gEfiMdeModulePkgTokenSpaceGuid.PcdConInConnectOnDemand|TRUE
 
+  # QEMU lacks a simulation for the INIT process.
+  # To address this, PcdFirstTimeWakeUpAPsBySipi set to FALSE to
+  # broadcast INIT-SIPI-SIPI for the first time.
+  gUefiCpuPkgTokenSpaceGuid.PcdFirstTimeWakeUpAPsBySipi|FALSE
+
 # Enable SHELL to build instead of just taking the binary
   gEfiMdePkgTokenSpaceGuid.PcdUefiLibMaxPrintBufferSize|16000
   gEfiShellPkgTokenSpaceGuid.PcdShellProfileMask|0x1f    # All profiles


### PR DESCRIPTION
## Description

This pull request introduces configuration changes to support QEMU acceleration mode (KVM) for the QemuQ35Pkg platform

Configuration Improvements:

- Set `PcdFirstTimeWakeUpAPsBySipi` to `FALSE` in `QemuQ35PkgCommon.dsc.inc` to ensure proper multi-core SMP initialization under Hyper-V nested virtualization (e.g., WSL2), addressing known issues with SIPI-only wakeup.

REF: https://github.com/tianocore/edk2/commit/1d76560146b169f0f6c39a3de9ee1fdc4c41dd0b

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validation OS 

## Integration Instructions

N/A