### PR TITLE
QemuQ35Pkg: Add PXE boot support to QemuRunner

### DIFF
--- a/Platforms/Docs/Q35/Features/feature_pxe_boot.md
+++ b/Platforms/Docs/Q35/Features/feature_pxe_boot.md
@@ -1,0 +1,67 @@
+# PXE Boot
+
+## Overview
+
+QemuQ35Pkg integrates PXE boot support through the `QemuRunner` plugin and the platform's network stack configuration.
+The plugin handles QEMU command-line construction for TFTP/DHCP, NIC selection, VirtualDrive suppression, and automatic
+boot order manipulation so that a single `stuart_build --FlashOnly` invocation can PXE boot an EFI application from a
+host-local file.
+
+QEMU's user-mode (slirp) networking provides the DHCP and TFTP services. See the
+[QEMU networking documentation](https://www.qemu.org/docs/master/system/devices/net.html) for details on slirp
+behavior and limitations.
+
+## Usage
+
+PXE boot requires `ENABLE_NETWORK` and `PXE_BOOT_FILE`:
+
+```bash
+stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB \
+    ENABLE_NETWORK=TRUE \
+    PXE_BOOT_FILE=/path/to/tftp/root/bootx64.efi \
+    --FlashOnly
+```
+
+`PXE_BOOT_FILE` is resolved to an absolute path. The parent directory becomes the TFTP root and the filename becomes
+the DHCP boot file advertised to the guest. For example, `PXE_BOOT_FILE=../tftp/bootx64.efi` yields
+`tftp=<abs path to ../tftp/>` and `bootfile=bootx64.efi` on the QEMU `-netdev user` argument.
+
+## QemuRunner Behavior
+
+When `PXE_BOOT_FILE` is set, QemuRunner.py changes the QEMU command line in four ways:
+
+1. The VirtualDrive (containing `startup.nsh`) is not mounted, preventing the UEFI shell from intercepting the boot.
+
+2. The `-netdev user` argument is extended with `tftp=<root>,bootfile=<name>`.
+
+3. The NIC is forced to `virtio-net-pci` because the firmware includes `QemuPkg/VirtioNetDxe/VirtioNet.inf`. Without
+   `PXE_BOOT_FILE`, QemuRunner selects the NIC based on context:
+
+   | Scenario                  | NIC             |
+   |---------------------------|-----------------|
+   | `PXE_BOOT_FILE` set       | `virtio-net-pci`|
+   | OS boot (no front page)   | `e1000e`        |
+   | Front page / UEFI shell   | `virtio-net-pci`|
+
+4. If no explicit `BOOT_TO_FRONT_PAGE` or `ALT_BOOT_ENABLE` flag is provided, the SMBIOS type=3 `version` field is set
+   to `Vol-`. This triggers the alternate boot sequence defined in
+   `Common/MU_OEM_SAMPLE/OemPkg/Library/MsBootPolicyLib/MsBootPolicyLib.c`:
+
+   ```c
+   static BOOT_SEQUENCE  BootSequenceUPH[] = {
+     MsBootUSB,
+     MsBootPXE4,
+     MsBootPXE6,
+     MsBootHDD,
+     MsBootDone
+   };
+   ```
+
+   Since no USB bootable media is present, the firmware falls through to PXE IPv4.
+
+## Platform Build Flags
+
+| Flag                      | Scope              | Effect                                                                                                                   |
+|---------------------------|--------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `ENABLE_NETWORK=TRUE`     | QemuRunner env var | Adds `-netdev user` and a NIC device to the QEMU command line. Without this, networking is disabled (`-net none`).       |
+| `PXE_BOOT_FILE=<path>`    | QemuRunner env var | Enables TFTP/DHCP args, selects `virtio-net-pci`, suppresses VirtualDrive, auto-sets alternate boot.                     |

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -170,7 +170,13 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         # If DFCI_VAR_STORE is enabled, don't enable the Virtual Drive
         dfci_var_store = env.GetValue("DFCI_VAR_STORE")
-        if dfci_var_store is None:
+        pxe_boot_file = env.GetValue("PXE_BOOT_FILE")
+
+        # Auto-enable alternate boot for PXE so the firmware uses the
+        # USB -> PXE4 -> PXE6 -> HDD sequence instead of normal boot order.
+        if pxe_boot_file is not None and not boot_selection:
+            boot_selection += ",version=Vol-"
+        if dfci_var_store is None and pxe_boot_file is None:
             # Mount disk with startup.nsh
             if os.path.isfile(VirtualDrive):
                 args += f" -drive file={VirtualDrive},if=virtio"
@@ -186,9 +192,19 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
                 # forward ports for robotframework 8270 and 8271
                 args += ",hostfwd=tcp::8270-:8270,hostfwd=tcp::8271-:8271"
 
-            if boot_to_front_page is None:
+            if pxe_boot_file is not None:
+                pxe_boot_path = Path(pxe_boot_file).resolve()
+                pxe_tftp_root = str(pxe_boot_path.parent)
+                pxe_file_name = pxe_boot_path.name
+                args += f",tftp={pxe_tftp_root},bootfile={pxe_file_name}"
+                logging.log(logging.INFO, f"PXE boot enabled: tftp={pxe_tftp_root}, bootfile={pxe_file_name}")
+
+            if pxe_boot_file is not None:
+                # PXE boot requires virtio-net-pci (firmware has VirtioNetDxe built in)
+                args += " -device virtio-net-pci,netdev=net0"
+            elif boot_to_front_page is None:
                 # Booting to Windows, use a PCI nic
-                args += " -device e1000,netdev=net0"
+                args += " -device e1000e,netdev=net0"
             else:
                 # Booting to UEFI, use virtio-net-pci
                 args += " -device virtio-net-pci,netdev=net0"


### PR DESCRIPTION
## Description

Add PXE boot support to the QemuRunner plugin. When PXE_BOOT_FILE is set, the plugin configures QEMU's slirp TFTP/DHCP, selects virtio-net-pci, suppresses the VirtualDrive, and auto-enables alternate boot order (Vol-) so the firmware boots via PXE IPv4.

Changes to QemuRunner.py:
- Add PXE_BOOT_FILE handling to construct tftp/bootfile netdev args
- Skip VirtualDrive mount when PXE_BOOT_FILE is set
- Force virtio-net-pci NIC for PXE boot
- Auto-set SMBIOS Vol- for alternate boot when no boot flag is given
- Change default OS-boot NIC from e1000 to e1000e

Add Platforms/Docs/Q35/Features/feature_pxe_boot.md documenting the PXE boot integration, QemuRunner behavior, and platform build flags.
For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

PXE booted HelloUefi.efi

## Integration Instructions

N/A