### PR TITLE
Redirect Hafnium submodules to GitHub mirrors

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -65,6 +65,11 @@ parameters:
   type: stepList
   default:
     - script: echo No extra steps provided
+- name: extra_steps
+  displayName: Extra Steps to Run Before Build Steps
+  type: stepList
+  default:
+    - script: echo No extra steps provided
 - name: extra_jobs
   displayName: Extra Jobs to be run after build
   type: jobList
@@ -94,6 +99,7 @@ jobs:
     os_type: ${{ parameters.os_type }}
     pool_name: ${{ parameters.pool_name }}
     extra_install_step: ${{ parameters.extra_install_step }}
+    extra_steps: ${{ parameters.extra_steps }}
     tool_chain_tag: $(tool_chain_tag)
     vm_image: $(vm_image)
     container_build: ${{ parameters.container_build }}

--- a/.azurepipelines/Platform-Build-Job.yml
+++ b/.azurepipelines/Platform-Build-Job.yml
@@ -86,6 +86,14 @@ jobs:
           vmImage: ${{ parameters.vm_image }}
 
       steps:
+      # Redirect Hafnium submodule URLs from git.trustedfirmware.org to GitHub mirrors
+      - script: |
+          git config --global url."https://github.com/TF-Hafnium/hafnium-prebuilts".insteadOf "https://git.trustedfirmware.org/hafnium/prebuilts"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-project-reference".insteadOf "https://git.trustedfirmware.org/hafnium/project/reference"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-dtc".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/dtc"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-googletest".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/googletest"
+        displayName: Redirect Submodule URLs
+
       # Potential Extra steps from specific build targets
       - ${{ item.Value.BuildExtraStep }}
 

--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -29,6 +29,13 @@ extends:
     container_build: true
     os_type: Linux
     rust_build: false
+    extra_steps:
+      - script: |
+          git config --global url."https://github.com/TF-Hafnium/hafnium-prebuilts".insteadOf "https://git.trustedfirmware.org/hafnium/prebuilts"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-project-reference".insteadOf "https://git.trustedfirmware.org/hafnium/project/reference"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-dtc".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/dtc"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-googletest".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/googletest"
+        displayName: Redirect Submodule URLs
     extra_cargo_steps:
       - script: pip install -r pip-requirements.txt --upgrade
         displayName: Install and Upgrade pip Modules

--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -28,6 +28,13 @@ extends:
     do_pr_eval: true
     os_type: Windows_NT
     rust_build: false
+    extra_steps:
+      - script: |
+          git config --global url."https://github.com/TF-Hafnium/hafnium-prebuilts".insteadOf "https://git.trustedfirmware.org/hafnium/prebuilts"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-project-reference".insteadOf "https://git.trustedfirmware.org/hafnium/project/reference"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-dtc".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/dtc"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-googletest".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/googletest"
+        displayName: Redirect Submodule URLs
     extra_cargo_steps:
       - script: pip install -r pip-requirements.txt --upgrade
         displayName: Install and Upgrade pip Modules

--- a/.github/workflows/build-haf-tfa.yml
+++ b/.github/workflows/build-haf-tfa.yml
@@ -50,6 +50,13 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global --add safe.directory $GITHUB_WORKSPACE
 
+      - name: Redirect Submodule URLs
+        run: |
+          git config --global url."https://github.com/TF-Hafnium/hafnium-prebuilts".insteadOf "https://git.trustedfirmware.org/hafnium/prebuilts"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-project-reference".insteadOf "https://git.trustedfirmware.org/hafnium/project/reference"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-dtc".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/dtc"
+          git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-googletest".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/googletest"
+
       - name: Stuart Setup
         run: python Platforms/QemuSbsaPkg/PlatformBuild.py --setup
 

--- a/.github/workflows/codeql-platform.yml
+++ b/.github/workflows/codeql-platform.yml
@@ -313,6 +313,14 @@ jobs:
       run: |
         subst Z: ${{ github.workspace }}
 
+    - name: Redirect Submodule URLs
+      shell: pwsh
+      run: |
+        git config --global url."https://github.com/TF-Hafnium/hafnium-prebuilts".insteadOf "https://git.trustedfirmware.org/hafnium/prebuilts"
+        git config --global url."https://github.com/TF-Hafnium/hafnium-project-reference".insteadOf "https://git.trustedfirmware.org/hafnium/project/reference"
+        git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-dtc".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/dtc"
+        git config --global url."https://github.com/TF-Hafnium/hafnium-third_party-googletest".insteadOf "https://git.trustedfirmware.org/hafnium/third_party/googletest"
+
     - name: Setup
       if: steps.get_platform_info.outputs.setup_supported == 'true'
       shell: pwsh


### PR DESCRIPTION
## Description

Nested submodules in the Hafnium repository are pointing to unreliable hosts. This commit updates the submodule URLs to point to GitHub mirrors.

- https://github.com/TF-Hafnium/hafnium-prebuilts
  - For: https://git.trustedfirmware.org/hafnium/prebuilts
- https://github.com/TF-Hafnium/hafnium-project-reference
  - For: https://git.trustedfirmware.org/hafnium/project/reference
- https://github.com/TF-Hafnium/hafnium-third_party-dtc
  - For: https://git.trustedfirmware.org/hafnium/third_party/dtc
- https://github.com/TF-Hafnium/hafnium-third_party-googletest
  - For: https://git.trustedfirmware.org/hafnium/third_party/googletest

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run HAF TF build on fork

## Integration Instructions

- N/A - Stabilizes CI