### PR TITLE
Add BootManagerPolicyProtocol Test to Q35 and SBSA

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
+++ b/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
@@ -1284,6 +1284,8 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
       #be tested in more of a release mode environment
       gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
   }
+
+  MdePkg/Test/UnitTest/BootManagerPolicyProtocol/BootManagerPolicyProtocolTest.inf
 !endif
   #########################################
   # SMM Phase modules

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1188,6 +1188,7 @@
     MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
   !endif
   # UefiTestingPkg/FunctionalSystemTests/MemoryAttributeProtocolFuncTestApp/MemoryAttributeProtocolFuncTestApp.inf # PROTOCOL NOT AVAILABLE ON SBSA
+  MdePkg/Test/UnitTest/BootManagerPolicyProtocol/BootManagerPolicyProtocolTest.inf
   MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestApp.inf
   MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibTestApp.inf
   MfciPkg/UnitTests/MfciPolicyParsingUnitTest/MfciPolicyParsingUnitTestApp.inf
@@ -1229,6 +1230,7 @@
       #be tested in more of a release mode environment
       gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0E
   }
+  
 !endif
 
   #


### PR DESCRIPTION
## Description

Add BootManagerPolicyProtocol Test to Q35 and SBSA.  Requires MU_BASECORE update

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [X] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Compiled and ran on both virtual platforms

## Integration Instructions

Add to DSC wherever your UEFI shell-based integration tests are located