### PR TITLE
Fix file_regex for QEMU SBSA

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformBuild.py
+++ b/Platforms/QemuQ35Pkg/PlatformBuild.py
@@ -394,6 +394,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         empty_drive = (self.env.GetValue("EMPTY_DRIVE").upper() == "TRUE")
         file_regex = self.env.GetValue("FILE_REGEX")
         startup_nsh = self.env.GetValue("STARTUP_NSH")
+        target_arch = self.env.GetValue("TARGET_ARCH", "X64")
 
         # Other configurable values
         output_base = self.env.GetValue("BUILD_OUTPUT_BASE")
@@ -425,7 +426,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         file_list = []
         if file_regex:
             for pattern in file_regex.split(","):
-                file_list.extend(Path(output_base, "X64").glob(pattern))
+                file_list.extend(Path(output_base, target_arch).glob(pattern))
 
        # If running tests, add the files and auto-generate a startup nsh
         if run_tests:

--- a/Platforms/QemuSbsaPkg/PlatformBuild.py
+++ b/Platforms/QemuSbsaPkg/PlatformBuild.py
@@ -956,6 +956,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         empty_drive = (self.env.GetValue("EMPTY_DRIVE").upper() == "TRUE")
         file_regex = self.env.GetValue("FILE_REGEX")
         startup_nsh = self.env.GetValue("STARTUP_NSH")
+        target_arch = self.env.GetValue("TARGET_ARCH", "AARCH64")
 
         # Other configurable values
         output_base = self.env.GetValue("BUILD_OUTPUT_BASE")
@@ -987,7 +988,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         file_list = []
         if file_regex:
             for pattern in file_regex.split(","):
-                file_list.extend(Path(output_base, "AARCH64").glob(pattern))
+                file_list.extend(Path(output_base, target_arch).glob(pattern))
 
        # If running tests, add the files and auto-generate a startup nsh
         if run_tests:


### PR DESCRIPTION
## Description

The file regex recently changed for SBSA caused the test apps not running due to the target folder being wrong.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA and fixed the test app not running issue.

## Integration Instructions

N/A
