### PR TITLE
platform-ci: Cancel current running CI on new push

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -16,6 +16,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: "platform-ci-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
 
   # A job to produce the environment constants for this repository, so that the build job can


### PR DESCRIPTION
## Description

This commit adds a concurrency group to the github workflow based on the github ref. with `cancel-in-progres: true`, a push to a branch to github will result in any previous instance of this workflow running for for this being canceled.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Performed a second push to this PR to ensure the previous running CI was cancelled.

<img width="757" height="608" alt="image" src="https://github.com/user-attachments/assets/08330b1e-a6c9-4121-be5c-cfc02731371a" />


## Integration Instructions

N/A
