### PR TITLE
platform-ci: Set FW Run timeout

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -156,6 +156,7 @@ jobs:
           working-directory: ${{ steps.short-path.outputs.short-path || github.workspace }}
 
       - name: Run ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.tool-chain}}
+        timeout-minutes: 15
         uses: ./.github/actions/build-platform
         with:
           command: 'flash'


### PR DESCRIPTION
## Description

Unlike azure pipelines, github workflows appear to have a 6 hour runtime limit for any given job. This commit adds a 15 minute timeout for platform flashing and booting to shell (and running tests) so the workflow does not stall for 6 hours when we freeze.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
