### PR TITLE
Sbsa: Carve Out MM Comm Buffer Into Reserved HOB

### DIFF
--- a/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
+++ b/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
@@ -24,6 +24,15 @@
 // Number of Virtual Memory Map Descriptors
 #define MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS  5
 
+#define RESOURCE_CAP  (EFI_RESOURCE_ATTRIBUTE_PRESENT | \
+                      EFI_RESOURCE_ATTRIBUTE_INITIALIZED | \
+                      EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE | \
+                      EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE | \
+                      EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE | \
+                      EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE | \
+                      EFI_RESOURCE_ATTRIBUTE_TESTED \
+                      )
+
 // MU_CHANGE START
 
 /**
@@ -174,19 +183,58 @@ InitializeMemoryConfiguration (
   }
 
   if (NewSize > PcdGet64 (PcdSystemMemorySize)) {
-    BuildResourceDescriptorV2 (
-      EFI_RESOURCE_SYSTEM_MEMORY,
-      (EFI_RESOURCE_ATTRIBUTE_PRESENT |
-       EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
-       EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
-       EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
-       EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
-       EFI_RESOURCE_ATTRIBUTE_TESTED),
-      NewBase + PcdGet64 (PcdSystemMemorySize),
-      NewSize - PcdGet64 (PcdSystemMemorySize),
-      EFI_MEMORY_WB,
-      NULL
-      );
+    if ((PcdGet64 (PcdMmBufferBase) > PcdGet64 (PcdSystemMemoryBase)) && (PcdGet64 (PcdMmBufferBase) < NewBase + NewSize)) {
+      // Carve out the MM buffer from the available memory, it is added as a HOB elsewhere. This only matters when
+      // adding more memory as PcdSystemMemoryBase + PcdSystemMemorySize is less than PcdMmBufferBase.
+
+      // Memory between the end of PcdSystemMemorySize and the start of the MM buffer
+      if (PcdGet64 (PcdMmBufferBase) > NewBase + PcdGet64 (PcdSystemMemorySize)) {
+        BuildResourceDescriptorV2 (
+          EFI_RESOURCE_SYSTEM_MEMORY,
+          (EFI_RESOURCE_ATTRIBUTE_PRESENT |
+           EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_TESTED),
+          NewBase + PcdGet64 (PcdSystemMemorySize),
+          PcdGet64 (PcdMmBufferBase) - (NewBase + PcdGet64 (PcdSystemMemorySize)),
+          EFI_MEMORY_WB,
+          NULL
+          );
+      }
+
+      // Memory after the MM buffer, if any remains
+      if (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize) < NewBase + NewSize) {
+        BuildResourceDescriptorV2 (
+          EFI_RESOURCE_SYSTEM_MEMORY,
+          (EFI_RESOURCE_ATTRIBUTE_PRESENT |
+           EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_TESTED),
+          PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
+          (NewBase + NewSize) - (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)),
+          EFI_MEMORY_WB,
+          NULL
+          );
+      }
+    } else {
+      BuildResourceDescriptorV2 (
+        EFI_RESOURCE_SYSTEM_MEMORY,
+        (EFI_RESOURCE_ATTRIBUTE_PRESENT |
+         EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+         EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+         EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+         EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+         EFI_RESOURCE_ATTRIBUTE_TESTED),
+        NewBase + PcdGet64 (PcdSystemMemorySize),
+        NewSize - PcdGet64 (PcdSystemMemorySize),
+        EFI_MEMORY_WB,
+        NULL
+        );
+    }
   } else {
     NewSize = PcdGet64 (PcdSystemMemorySize);
   }
@@ -264,12 +312,6 @@ ArmPlatformGetVirtualMemoryMap (
   }
 
   BuildMemoryAllocationHob (
-    PcdGet64 (PcdMmBufferBase),
-    PcdGet64 (PcdMmBufferSize),
-    EfiReservedMemoryType
-    );
-
-  BuildMemoryAllocationHob (
     PcdGet64 (PcdAdvancedLoggerBase),
     PcdGet32 (PcdAdvancedLoggerPages) * EFI_PAGE_SIZE,
     EfiRuntimeServicesData
@@ -327,7 +369,16 @@ ArmPlatformGetVirtualMemoryMap (
   VirtualMemoryTable[3].PhysicalBase = PcdGet64 (PcdMmBufferBase);
   VirtualMemoryTable[3].VirtualBase  = PcdGet64 (PcdMmBufferBase);
   VirtualMemoryTable[3].Length       = PcdGet64 (PcdMmBufferSize);
-  VirtualMemoryTable[3].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_UNCACHED_UNBUFFERED;
+  VirtualMemoryTable[3].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
+
+  BuildResourceDescriptorV2 (
+    EFI_RESOURCE_MEMORY_RESERVED,
+    RESOURCE_CAP,
+    VirtualMemoryTable[3].PhysicalBase,
+    VirtualMemoryTable[3].Length,
+    EFI_MEMORY_WB,
+    NULL
+    );
 
   // End of Table
   ZeroMem (&VirtualMemoryTable[4], sizeof (ARM_MEMORY_REGION_DESCRIPTOR));


### PR DESCRIPTION
## Description

The latest ArmMmCommunicationDxe, pulled in with the new basecore, expects that the MM Comm Buffer region is either not produced in a HOB or is in a reserved HOB. SBSA was producing it in a system memory HOB. As such, it was failing in that driver.

This updates SBSA to produce a reserved HOB and split up the system memory HOB.

It also updates the cacheability of this region to be WB, as it did not need to be WC.

Note, this only contains one of the commits from patina-qemu because the change to map all MMIO in resource descriptor HOBs was not brought here.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

No longer hits assert.

## Integration Instructions

N/A.
