### PR TITLE
QemuQ35Pkg: drop stale Tpm2DebugLib mapping (fixes TPM_ENABLE=TRUE bu…

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
+++ b/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
@@ -246,7 +246,6 @@
 !if $(TPM_ENABLE) == TRUE
   Tcg2PhysicalPresenceLib |QemuPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib       |SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
-  Tpm2DebugLib            |SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.inf
 !endif
 
   # Shell Libraries


### PR DESCRIPTION
Fixes #1426 

## Description

Building QemuQ35Pkg with BLD_*_TPM_ENABLE=TRUE failed because QemuQ35PkgCommon.dsc.inc mapped the Tpm2DebugLib library class to SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.inf, but that class and its INF were removed from MU_BASECORE (absent as of v2025110001.x). No module in the platform consumes the class, so the mapping is vestigial.

Because the referenced INF path does not exist on disk, the failure surfaces in the OverrideValidation prebuild plugin: get_dsc_inf_list() enumerates dscp.Libs (including this mapping), GetAbsolutePathOnThisSystemFromEdk2RelativePath() returns None for the missing INF, and that None is passed into override_detect_process() (os.path.normpath(None)), crashing the prebuild. Default CI does not hit this because TPM_ENABLE defaults to FALSE. The failure is target-independent: TARGET=RELEASE and TARGET=DEBUG fail identically.

Remove the dead mapping (no replacement needed; the class has no consumers, so no instance is required). Validated: Override/Deprecation Validation runs cleanly and full GCC5/X64 builds succeed for both DEBUG and RELEASE with TPM_ENABLE=TRUE. The DEBUG firmware was further booted under QEMU with an swtpm vTPM: PEI TPM2Startup success, PCR banks reallocated to SHA256, and DXE Tcg2Dxe installs Tcg2Protocol and measures PCR7 (SecureBoot/PK/KEK/db/dbx) with no asserts.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

 - Full build succeeds: Q35TPM_RC=0, 0204 Images Verified, Summary: Success (~17 min). Tcg2Pei, Tcg2Dxe, Tcg2ConfigPei all build.
 - Booted headless under QEMU with an swtpm vTPM: PEI TPM2Startup: TPM_RC_SUCCESS, PCR banks reallocated to SHA256; DXE Tcg2Dxe installs Tcg2Protocol and measures PCR7 (SecureBoot/PK/KEK/db/dbx) and PCR1 (boot vars); boot reaches BDS with no asserts.

## Integration Instructions

N/A
