### PR TITLE
QemuRunner TPM Updates for Q35 and SBSA

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -151,13 +151,18 @@ jobs:
       - name: Install dependencies
         run: pip install -r pip-requirements.txt
 
-      # Install swtpm and prepare its state dir for TPM-enabled runs. Exposes
-      # TPM_ARGS for the build/run steps below.
+      # Install swtpm on all Linux runners. QemuRunner.py launches swtpm by
+      # default (SWTPM_ENABLE=TRUE) on Linux.
       - name: Setup swtpm
-        if: matrix.variant == 'TPM'
+        if: runner.os == 'Linux'
         run: |
           apt-get update
           apt-get install -y swtpm swtpm-tools
+
+      # Expose TPM_ARGS for the build/run steps below on TPM-enabled runs.
+      - name: Set TPM build args
+        if: matrix.variant == 'TPM'
+        run: |
           echo "TPM_ARGS=BLD_*_TPM_ENABLE=TRUE" >> $GITHUB_ENV
 
       # Run the build-platform action, which calls stuart_setup, stuart_update, and stuart_build

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y swtpm swtpm-tools
-          echo "TPM_ARGS=BLD_*_TPM_ENABLE=TRUE SWTPM_ENABLE=TRUE" >> $GITHUB_ENV
+          echo "TPM_ARGS=BLD_*_TPM_ENABLE=TRUE" >> $GITHUB_ENV
 
       # Run the build-platform action, which calls stuart_setup, stuart_update, and stuart_build
       - name: Prepare and Build ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.tool-chain}}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -158,8 +158,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y swtpm swtpm-tools
-          mkdir -p /tmp/mytpm1
-          echo "TPM_ARGS=BLD_*_TPM_ENABLE=TRUE TPM_DEV=/tmp/mytpm1/swtpm-sock" >> $GITHUB_ENV
+          echo "TPM_ARGS=BLD_*_TPM_ENABLE=TRUE SWTPM_ENABLE=TRUE" >> $GITHUB_ENV
 
       # Run the build-platform action, which calls stuart_setup, stuart_update, and stuart_build
       - name: Prepare and Build ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.tool-chain}}

--- a/Platforms/Docs/Common/Features/feature_tpm.md
+++ b/Platforms/Docs/Common/Features/feature_tpm.md
@@ -10,27 +10,17 @@ Swtpm can be installed from the linux package managers.
 sudo apt-get install swtpm
 ```
 
-To start the TPM emulator, invoke swtpm with a state file location and character
-device.
+To run using this TPM, build and run with the following options. `SWTPM_ENABLE`
+enables the swtpm emulator that is started automatically by `QemuRunner.py`.
 
+for the Q35 platform:
 ```bash
-mkdir /tmp/mytpm1
-swtpm socket --tpmstate dir=/tmp/mytpm1 \
-  --ctrl type=unixio,path=/tmp/mytpm1/swtpm-sock \
-  --tpm2 \
-  --log level=20
+stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM_ENABLE=TRUE SWTPM_ENABLE=TRUE
 ```
 
-To run Q35 using this TPM, build and run with the following options. `TPM_DEV` should
-point to the path of the character device from the above swtpm command.
-
+for the SBSA platform:
 ```bash
-stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM_ENABLE=TRUE TPM_DEV=/tmp/mytpm1/swtpm-sock
-```
-
-or for SBSA platform:
-```bash
-stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM2_ENABLE=TRUE TPM_DEV=/tmp/mytpm1/swtpm-sock
+stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM2_ENABLE=TRUE SWTPM_ENABLE=TRUE
 ```
 
 In the window running swtpm, there should be output from the TPM communication.

--- a/Platforms/Docs/Common/Features/feature_tpm.md
+++ b/Platforms/Docs/Common/Features/feature_tpm.md
@@ -12,15 +12,16 @@ sudo apt-get install swtpm
 
 To run using this TPM, build and run with the following options. `SWTPM_ENABLE`
 enables the swtpm emulator that is started automatically by `QemuRunner.py`.
+`SWTPM_ENABLE` is `TRUE` by default.
 
 for the Q35 platform:
 ```bash
-stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM_ENABLE=TRUE SWTPM_ENABLE=TRUE
+stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM_ENABLE=TRUE
 ```
 
 for the SBSA platform:
 ```bash
-stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM2_ENABLE=TRUE SWTPM_ENABLE=TRUE
+stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM2_ENABLE=TRUE
 ```
 
 In the window running swtpm, there should be output from the TPM communication.

--- a/Platforms/Docs/Q35/Features/feature_tpm_replay.md
+++ b/Platforms/Docs/Q35/Features/feature_tpm_replay.md
@@ -22,7 +22,7 @@ Or, as a `stuart_build` argument:
 
 ```bash
 > stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM_ENABLE=TRUE \
-               BLD_*_TPM_REPLAY_ENABLED=TRUE SWTPM_ENABLE=TRUE
+               BLD_*_TPM_REPLAY_ENABLED=TRUE
 ```
 
 Note that the TPM driver stack is also disabled by default in QEMU firmware. It requires a TPM emulator and currently

--- a/Platforms/Docs/Q35/Features/feature_tpm_replay.md
+++ b/Platforms/Docs/Q35/Features/feature_tpm_replay.md
@@ -22,7 +22,7 @@ Or, as a `stuart_build` argument:
 
 ```bash
 > stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --flashrom TOOL_CHAIN_TAG=GCC5 BLD_*_TPM_ENABLE=TRUE \
-               BLD_*_TPM_REPLAY_ENABLED=TRUE TPM_DEV=/tmp/mytpm1/swtpm-sock
+               BLD_*_TPM_REPLAY_ENABLED=TRUE SWTPM_ENABLE=TRUE
 ```
 
 Note that the TPM driver stack is also disabled by default in QEMU firmware. It requires a TPM emulator and currently

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -48,22 +48,15 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
 
     @staticmethod
-    def RunThread(env):
-        """Runs TPM in a separate thread"""
-        sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
-        if str(sw_tpm_enable).upper() == "FALSE":
-            logging.critical("SWTPM Disabled")
-            return
-
-        tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
-        tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
+    def RunSwTpmThread(tpm_dir, tpm_sock):
+        """Runs SWTPM in a separate thread"""
         tpm_cmd = "swtpm"
         tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
 
         # Start the TPM emulator in a separate thread
         ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
         if ret != 0:
-            logging.critical("Failed to start TPM emulator.")
+            logging.critical("Failed to start SWTPM emulator.")
             return
 
     @staticmethod
@@ -219,18 +212,18 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += f" -smbios type=1,manufacturer=Palindrome,product=\"QEMU Q35\",family=QEMU,version=\"{'.'.join(qemu_version)}\",serial=42-42-42-42,uuid=9de555c0-05d7-4aa1-84ab-bb511e3a8bef"
         args += f" -smbios type=3,manufacturer=Palindrome,serial=40-41-42-43{boot_selection}"
 
-        tpm_dev = env.GetValue("TPM_DEV", "FALSE")
-        thread = None
-        if str(tpm_dev).upper() == "TRUE":
+        sw_tpm_thread = None
+        sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "FALSE")
+        if str(sw_tpm_enable).upper() == "TRUE":
             tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
             tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
             args += f" -chardev socket,id=chrtpm,path={tpm_sock}"
             args += " -tpmdev emulator,id=tpm0,chardev=chrtpm"
             args += " -device tpm-tis,tpmdev=tpm0"
 
-            logging.critical("Starting TPM emulator in a different thread.")
-            thread = threading.Thread(target=QemuRunner.RunThread, args=(env,))
-            thread.start()
+            logging.info("Starting TPM emulator in a different thread.")
+            sw_tpm_thread = threading.Thread(target=QemuRunner.RunSwTpmThread, args=(tpm_dir, tpm_sock))
+            sw_tpm_thread.start()
 
         if (env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):
             args += " -display none"  # no graphics
@@ -287,7 +280,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway
             utility_functions.RunCmd('stty', 'sane', capture=False)
 
-        if thread is not None:
-            logging.critical("Terminate TPM emulator by using Crtl + C now!")
-            thread.join()
+        if sw_tpm_thread is not None:
+            sw_tpm_thread.join()
+
         return ret

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -50,13 +50,15 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
     @staticmethod
     def RunThread(env):
         """Runs TPM in a separate thread"""
-        tpm_path = env.GetValue("TPM_DEV")
-        if tpm_path is None:
-            logging.critical("TPM Path Invalid")
+        sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
+        if str(sw_tpm_enable).upper() == "FALSE":
+            logging.critical("SWTPM Disabled")
             return
 
+        tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
+        tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
         tpm_cmd = "swtpm"
-        tpm_args = f"socket --tpmstate dir={'/'.join(tpm_path.rsplit('/', 1)[:-1])} --ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
+        tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
 
         # Start the TPM emulator in a separate thread
         ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
@@ -217,12 +219,18 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += f" -smbios type=1,manufacturer=Palindrome,product=\"QEMU Q35\",family=QEMU,version=\"{'.'.join(qemu_version)}\",serial=42-42-42-42,uuid=9de555c0-05d7-4aa1-84ab-bb511e3a8bef"
         args += f" -smbios type=3,manufacturer=Palindrome,serial=40-41-42-43{boot_selection}"
 
-        # TPM in Linux
-        tpm_dev = env.GetValue("TPM_DEV")
-        if tpm_dev is not None:
-            args += f" -chardev socket,id=chrtpm,path={tpm_dev}"
+        tpm_dev = env.GetValue("TPM_DEV", "FALSE")
+        thread = None
+        if str(tpm_dev).upper() == "TRUE":
+            tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
+            tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
+            args += f" -chardev socket,id=chrtpm,path={tpm_sock}"
             args += " -tpmdev emulator,id=tpm0,chardev=chrtpm"
             args += " -device tpm-tis,tpmdev=tpm0"
+
+            logging.critical("Starting TPM emulator in a different thread.")
+            thread = threading.Thread(target=QemuRunner.RunThread, args=(env,))
+            thread.start()
 
         if (env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):
             args += " -display none"  # no graphics
@@ -254,12 +262,6 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             except Exception:
                 std_handle = None
 
-        thread = None
-        if tpm_dev:
-            # also spawn the TPM emulator on a different thread
-            logging.critical("Starting TPM emulator in a different thread.")
-            thread = threading.Thread(target=QemuRunner.RunThread, args=(env,))
-            thread.start()
 
         # Run QEMU
         try:

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -213,7 +213,9 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += f" -smbios type=3,manufacturer=Palindrome,serial=40-41-42-43{boot_selection}"
 
         sw_tpm_thread = None
-        sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "FALSE")
+        sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "TRUE")
+        if os.name == 'nt':
+            sw_tpm_enable = "FALSE"
         if str(sw_tpm_enable).upper() == "TRUE":
             tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
             tpm_sock = os.path.join(tpm_dir, "swtpm-sock")

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -125,7 +125,9 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
                 code_fd + ",readonly=on"
 
         sw_tpm_thread = None
-        sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "FALSE")
+        sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "TRUE")
+        if os.name == 'nt':
+            sw_tpm_enable = "FALSE"
         if str(sw_tpm_enable).upper() == "TRUE":
             tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
             tpm_sock = os.path.join(tpm_dir, "swtpm-sock")

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -46,14 +46,16 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
     @staticmethod
     def RunThread(env):
-        ''' Runs TPM in a separate thread '''
-        tpm_path = env.GetValue("TPM_DEV")
-        if tpm_path is None:
-            logging.critical("TPM Path Invalid")
+        """Runs TPM in a separate thread"""
+        sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
+        if str(sw_tpm_enable).upper() == "FALSE":
+            logging.critical("SWTPM Disabled")
             return
 
+        tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
+        tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
         tpm_cmd = "swtpm"
-        tpm_args = f"socket --tpmstate dir={"/".join(tpm_path.rsplit("/", 1)[:-1])} --ctrl type=unixio,path={tpm_path} --tpm2 --log level=1"
+        tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
 
         # Start the TPM emulator in a separate thread
         ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
@@ -129,10 +131,12 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += " -drive if=pflash,format=raw,unit=1,file=" + \
                 code_fd + ",readonly=on"
 
-        tpm_dev = env.GetValue("TPM_DEV")
+        tpm_dev = env.GetValue("TPM_DEV", "FALSE")
         thread = None
-        if tpm_dev is not None:
-            args += f" -chardev socket,id=chrtpm,path={tpm_dev}"
+        if str(tpm_dev).upper() == "TRUE":
+            tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
+            tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
+            args += f" -chardev socket,id=chrtpm,path={tpm_sock}"
             args += " -tpmdev emulator,id=tpm0,chardev=chrtpm"
 
             # also spawn the TPM emulator on a different thread

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -45,22 +45,15 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
 
     @staticmethod
-    def RunThread(env):
-        """Runs TPM in a separate thread"""
-        sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
-        if str(sw_tpm_enable).upper() == "FALSE":
-            logging.critical("SWTPM Disabled")
-            return
-
-        tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
-        tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
+    def RunSwTpmThread(tpm_dir, tpm_sock):
+        """Runs SWTPM in a separate thread"""
         tpm_cmd = "swtpm"
         tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
 
         # Start the TPM emulator in a separate thread
         ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
         if ret != 0:
-            logging.critical("Failed to start TPM emulator.")
+            logging.critical("Failed to start SWTPM emulator.")
             return
 
 
@@ -131,18 +124,17 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += " -drive if=pflash,format=raw,unit=1,file=" + \
                 code_fd + ",readonly=on"
 
-        tpm_dev = env.GetValue("TPM_DEV", "FALSE")
-        thread = None
-        if str(tpm_dev).upper() == "TRUE":
+        sw_tpm_thread = None
+        sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "FALSE")
+        if str(sw_tpm_enable).upper() == "TRUE":
             tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
             tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
             args += f" -chardev socket,id=chrtpm,path={tpm_sock}"
             args += " -tpmdev emulator,id=tpm0,chardev=chrtpm"
 
-            # also spawn the TPM emulator on a different thread
-            logging.critical("Starting TPM emulator in a different thread.")
-            thread = threading.Thread(target=QemuRunner.RunThread, args=(env,))
-            thread.start()
+            logging.info("Starting TPM emulator in a different thread.")
+            sw_tpm_thread = threading.Thread(target=QemuRunner.RunSwTpmThread, args=(tpm_dir, tpm_sock))
+            sw_tpm_thread.start()
 
         # Add XHCI USB controller and mouse
         args += " -device qemu-xhci,id=usb"
@@ -210,8 +202,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway
             utility_functions.RunCmd('stty', 'sane', capture=False)
 
-        if thread is not None:
-            logging.critical("Terminate TPM emulator by using Crtl + C now!")
-            thread.join()
+        if sw_tpm_thread is not None:
+            sw_tpm_thread.join()
 
         return ret

--- a/docs/TPM/TpmQemuQ35.md
+++ b/docs/TPM/TpmQemuQ35.md
@@ -29,13 +29,13 @@ See [swtpm Setup](#swtpm-setup) for the full setup commands.
 
 ## Build Configuration
 
-The TPM is disabled by default. To enable it, set `BLD_*_TPM_ENABLE=TRUE` and `TPM_DEV=TRUE`
+The TPM is disabled by default. To enable it, set `BLD_*_TPM_ENABLE=TRUE` and `SWTPM_ENABLE=TRUE`
 on the command line or in a BuildConfig.conf file placed at the root level of the repo:
 
 ```bash
 stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM_ENABLE=TRUE \
-  TPM_DEV=TRUE
+  SWTPM_ENABLE=TRUE
 ```
 
 The following defines control TPM behavior in `QemuQ35Pkg.dsc`:
@@ -324,24 +324,17 @@ swtpm socket \
 
 ### Automatic Setup (QemuRunner)
 
-When `TPM_DEV=TRUE`, `QemuRunner.py` automatically starts swtpm in a background thread
+When `SWTPM_ENABLE=TRUE`, `QemuRunner.py` automatically starts swtpm in a background thread
 before launching QEMU. The swtpm state directory is set to `BUILD_OUTPUT_BASE` and the
 Unix socket is placed at `{BUILD_OUTPUT_BASE}/swtpm-sock`:
 
 ```python
 # Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
 @staticmethod
-def RunThread(env):
-    sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
-    if str(sw_tpm_enable).upper() == "FALSE":
-        logging.critical("SWTPM Disabled")
-        return
-
-    tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
-    tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
+def RunSwTpmThread(tpm_dir, tpm_sock):
+    """Runs TPM in a separate thread"""
     tpm_cmd = "swtpm"
     tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
-    utility_functions.RunCmd(tpm_cmd, tpm_args)
 ```
 
 The thread is launched before QEMU starts and joined after QEMU exits. The user is
@@ -349,8 +342,8 @@ prompted to press Ctrl+C to terminate swtpm at shutdown.
 
 ### QEMU Arguments
 
-When `TPM_DEV=TRUE`, `QemuRunner.py` adds the following three arguments to the QEMU
-command line for Q35 (with the socket path under `BUILD_OUTPUT_BASE`):
+When `SWTPM_ENABLE=TRUE`, `QemuRunner.py` adds the following to the QEMU command line
+(with the socket path under `BUILD_OUTPUT_BASE`):
 
 ```text
 -chardev socket,id=chrtpm,path={BUILD_OUTPUT_BASE}/swtpm-sock

--- a/docs/TPM/TpmQemuQ35.md
+++ b/docs/TPM/TpmQemuQ35.md
@@ -29,13 +29,13 @@ See [swtpm Setup](#swtpm-setup) for the full setup commands.
 
 ## Build Configuration
 
-The TPM is disabled by default. To enable it, pass the build define and provide the swtpm
-socket path or provide it in a BuildConfig.conf file placed at the root level of the repo:
+The TPM is disabled by default. To enable it, set `BLD_*_TPM_ENABLE=TRUE` and `TPM_DEV=TRUE`
+on the command line or in a BuildConfig.conf file placed at the root level of the repo:
 
 ```bash
 stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM_ENABLE=TRUE \
-  TPM_DEV=/tmp/mytpm1/swtpm-sock
+  TPM_DEV=TRUE
 ```
 
 The following defines control TPM behavior in `QemuQ35Pkg.dsc`:
@@ -324,19 +324,23 @@ swtpm socket \
 
 ### Automatic Setup (QemuRunner)
 
-When the `TPM_DEV` environment variable is set, `QemuRunner.py` automatically starts
-swtpm in a background thread before launching QEMU:
+When `TPM_DEV=TRUE`, `QemuRunner.py` automatically starts swtpm in a background thread
+before launching QEMU. The swtpm state directory is set to `BUILD_OUTPUT_BASE` and the
+Unix socket is placed at `{BUILD_OUTPUT_BASE}/swtpm-sock`:
 
 ```python
 # Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
 @staticmethod
 def RunThread(env):
-    tpm_path = env.GetValue("TPM_DEV")
+    sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
+    if str(sw_tpm_enable).upper() == "FALSE":
+        logging.critical("SWTPM Disabled")
+        return
+
+    tpm_dir = env.GetValue("BUILD_OUTPUT_BASE")
+    tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
     tpm_cmd = "swtpm"
-    tpm_args = (
-        f"socket --tpmstate dir={'/'.join(tpm_path.rsplit('/', 1)[:-1])} "
-        f"--ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
-    )
+    tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
     utility_functions.RunCmd(tpm_cmd, tpm_args)
 ```
 
@@ -345,10 +349,11 @@ prompted to press Ctrl+C to terminate swtpm at shutdown.
 
 ### QEMU Arguments
 
-The `QemuCommandBuilder.with_tpm()` method adds three arguments for Q35:
+When `TPM_DEV=TRUE`, `QemuRunner.py` adds the following three arguments to the QEMU
+command line for Q35 (with the socket path under `BUILD_OUTPUT_BASE`):
 
 ```text
--chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
+-chardev socket,id=chrtpm,path={BUILD_OUTPUT_BASE}/swtpm-sock
 -tpmdev emulator,id=tpm0,chardev=chrtpm
 -device tpm-tis,tpmdev=tpm0
 ```

--- a/docs/TPM/TpmQemuQ35.md
+++ b/docs/TPM/TpmQemuQ35.md
@@ -29,13 +29,12 @@ See [swtpm Setup](#swtpm-setup) for the full setup commands.
 
 ## Build Configuration
 
-The TPM is disabled by default. To enable it, set `BLD_*_TPM_ENABLE=TRUE` and `SWTPM_ENABLE=TRUE`
-on the command line or in a BuildConfig.conf file placed at the root level of the repo:
+The TPM is disabled by default. To enable it, set `BLD_*_TPM_ENABLE=TRUE` on the command line or in a
+BuildConfig.conf file placed at the root level of the repo:
 
 ```bash
 stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM_ENABLE=TRUE \
-  SWTPM_ENABLE=TRUE
 ```
 
 The following defines control TPM behavior in `QemuQ35Pkg.dsc`:
@@ -337,8 +336,9 @@ def RunSwTpmThread(tpm_dir, tpm_sock):
     tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
 ```
 
-The thread is launched before QEMU starts and joined after QEMU exits. The user is
-prompted to press Ctrl+C to terminate swtpm at shutdown.
+The thread is launched before QEMU starts and joined after QEMU exits. Note that the SWTPM
+is enabled by default. You can disable it by setting `SWTPM_ENABLE=FALSE` from the command
+line or in the BuildConfig.conf file.
 
 ### QEMU Arguments
 

--- a/docs/TPM/TpmQemuSbsa.md
+++ b/docs/TPM/TpmQemuSbsa.md
@@ -36,13 +36,13 @@ See [swtpm Setup](#swtpm-setup) for the full setup commands.
 
 ## Build Configuration
 
-The TPM is disabled by default. To enable it, pass the build define and provide the swtpm
-socket path or provide it in a BuildConfig.conf file placed at the root level of the repo:
+The TPM is disabled by default. To enable it, set `BLD_*_TPM2_ENABLE=TRUE` and `TPM_DEV=TRUE`
+on the command line or in a BuildConfig.conf file placed at the root level of the repo:
 
 ```bash
 stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM2_ENABLE=TRUE \
-  TPM_DEV=/tmp/mytpm1/swtpm-sock
+  TPM_DEV=TRUE
 ```
 
 The following defines control TPM behavior in `QemuSbsaPkg.dsc`:
@@ -274,7 +274,7 @@ The external CRB connects to the `swtpm` process through QEMU's chardev/tpmdev
 infrastructure:
 
 ```text
-QEMU args: -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
+QEMU args: -chardev socket,id=chrtpm,path={BUILD_OUTPUT_BASE}/swtpm-sock
            -tpmdev emulator,id=tpm0,chardev=chrtpm
 ```
 
@@ -518,19 +518,23 @@ swtpm socket \
 
 ### Automatic Setup (QemuRunner)
 
-When the `TPM_DEV` environment variable is set, `QemuRunner.py` automatically starts
-swtpm in a background thread before launching QEMU:
+When `TPM_DEV=TRUE`, `QemuRunner.py` automatically starts swtpm in a background thread
+before launching QEMU. The swtpm state directory is set to `BUILD_OUTPUT_BASE` and the
+Unix socket is placed at `{BUILD_OUTPUT_BASE}/swtpm-sock`:
 
 ```python
 # Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
 @staticmethod
 def RunThread(env):
-    tpm_path = env.GetValue("TPM_DEV")
-    tpm_cmd = "swtpm"
-    tpm_args = (
-        f"socket --tpmstate dir={'/'.join(tpm_path.rsplit('/', 1)[:-1])} "
-        f"--ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
-    )
+    sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
+    if str(sw_tpm_enable).upper() == "FALSE":
+        logging.critical("SWTPM Disabled")
+        return
+
+    tpm_dir  = env.GetValue("BUILD_OUTPUT_BASE")
+    tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
+    tpm_cmd  = "swtpm"
+    tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
     utility_functions.RunCmd(tpm_cmd, tpm_args)
 ```
 
@@ -539,10 +543,11 @@ prompted to press Ctrl+C to terminate swtpm at shutdown.
 
 ### QEMU Arguments
 
-The `QemuCommandBuilder.with_tpm()` method adds:
+When `TPM_DEV=TRUE`, `QemuRunner.py` adds the following to the QEMU command line
+(with the socket path under `BUILD_OUTPUT_BASE`):
 
 ```text
--chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
+-chardev socket,id=chrtpm,path={BUILD_OUTPUT_BASE}/swtpm-sock
 -tpmdev emulator,id=tpm0,chardev=chrtpm
 ```
 

--- a/docs/TPM/TpmQemuSbsa.md
+++ b/docs/TPM/TpmQemuSbsa.md
@@ -36,13 +36,13 @@ See [swtpm Setup](#swtpm-setup) for the full setup commands.
 
 ## Build Configuration
 
-The TPM is disabled by default. To enable it, set `BLD_*_TPM2_ENABLE=TRUE` and `TPM_DEV=TRUE`
+The TPM is disabled by default. To enable it, set `BLD_*_TPM2_ENABLE=TRUE` and `SWTPM_ENABLE=TRUE`
 on the command line or in a BuildConfig.conf file placed at the root level of the repo:
 
 ```bash
 stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM2_ENABLE=TRUE \
-  TPM_DEV=TRUE
+  SWTPM_ENABLE=TRUE
 ```
 
 The following defines control TPM behavior in `QemuSbsaPkg.dsc`:
@@ -518,24 +518,17 @@ swtpm socket \
 
 ### Automatic Setup (QemuRunner)
 
-When `TPM_DEV=TRUE`, `QemuRunner.py` automatically starts swtpm in a background thread
+When `SWTPM_ENABLE=TRUE`, `QemuRunner.py` automatically starts swtpm in a background thread
 before launching QEMU. The swtpm state directory is set to `BUILD_OUTPUT_BASE` and the
 Unix socket is placed at `{BUILD_OUTPUT_BASE}/swtpm-sock`:
 
 ```python
 # Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
 @staticmethod
-def RunThread(env):
-    sw_tpm_enable = env.GetValue("TPM_DEV", "FALSE")
-    if str(sw_tpm_enable).upper() == "FALSE":
-        logging.critical("SWTPM Disabled")
-        return
-
-    tpm_dir  = env.GetValue("BUILD_OUTPUT_BASE")
-    tpm_sock = os.path.join(tpm_dir, "swtpm-sock")
-    tpm_cmd  = "swtpm"
+def RunSwTpmThread(tpm_dir, tpm_sock):
+    """Runs SWTPM in a separate thread"""
+    tpm_cmd = "swtpm"
     tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
-    utility_functions.RunCmd(tpm_cmd, tpm_args)
 ```
 
 The thread is launched before QEMU starts and joined after QEMU exits. The user is
@@ -543,7 +536,7 @@ prompted to press Ctrl+C to terminate swtpm at shutdown.
 
 ### QEMU Arguments
 
-When `TPM_DEV=TRUE`, `QemuRunner.py` adds the following to the QEMU command line
+When `SWTPM_ENABLE=TRUE`, `QemuRunner.py` adds the following to the QEMU command line
 (with the socket path under `BUILD_OUTPUT_BASE`):
 
 ```text

--- a/docs/TPM/TpmQemuSbsa.md
+++ b/docs/TPM/TpmQemuSbsa.md
@@ -36,13 +36,12 @@ See [swtpm Setup](#swtpm-setup) for the full setup commands.
 
 ## Build Configuration
 
-The TPM is disabled by default. To enable it, set `BLD_*_TPM2_ENABLE=TRUE` and `SWTPM_ENABLE=TRUE`
-on the command line or in a BuildConfig.conf file placed at the root level of the repo:
+The TPM is disabled by default. To enable it, set `BLD_*_TPM2_ENABLE=TRUE` on the command line or in a
+BuildConfig.conf file placed at the root level of the repo:
 
 ```bash
 stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM2_ENABLE=TRUE \
-  SWTPM_ENABLE=TRUE
 ```
 
 The following defines control TPM behavior in `QemuSbsaPkg.dsc`:
@@ -531,8 +530,9 @@ def RunSwTpmThread(tpm_dir, tpm_sock):
     tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
 ```
 
-The thread is launched before QEMU starts and joined after QEMU exits. The user is
-prompted to press Ctrl+C to terminate swtpm at shutdown.
+The thread is launched before QEMU starts and joined after QEMU exits. Note that the SWTPM
+is enabled by default. You can disable it by setting `SWTPM_ENABLE=FALSE` from the command
+line or in the BuildConfig.conf file.
 
 ### QEMU Arguments
 

--- a/docs/TPM/TpmShellAppQemu.md
+++ b/docs/TPM/TpmShellAppQemu.md
@@ -36,7 +36,6 @@ On SBSA, the TpmShellApp is placed directly in the firmware volume, which is map
 ```bash
 stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM2_ENABLE=TRUE \
-  SWTPM_ENABLE=TRUE
 ```
 
 At the UEFI shell, run:
@@ -65,7 +64,6 @@ binaries are copied to the virtual drive:
 ```bash
 stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM_ENABLE=TRUE \
-  SWTPM_ENABLE=TRUE \
   FILE_REGEX=TpmShellApp.efi
 ```
 

--- a/docs/TPM/TpmShellAppQemu.md
+++ b/docs/TPM/TpmShellAppQemu.md
@@ -36,7 +36,7 @@ On SBSA, the TpmShellApp is placed directly in the firmware volume, which is map
 ```bash
 stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM2_ENABLE=TRUE \
-  TPM_DEV=/tmp/mytpm1/swtpm-sock
+  SWTPM_ENABLE=TRUE
 ```
 
 At the UEFI shell, run:
@@ -65,7 +65,7 @@ binaries are copied to the virtual drive:
 ```bash
 stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM_ENABLE=TRUE \
-  TPM_DEV=/tmp/mytpm1/swtpm-sock \
+  SWTPM_ENABLE=TRUE \
   FILE_REGEX=TpmShellApp.efi
 ```
 


### PR DESCRIPTION
## Description

Updated QemuRunner.py to no longer point to the /tmp/mytpm1 directory from TPM_DEV, instead it now points to our build output folder. This prevents an issue where creation of the directory is a manual step and running could fail if a user does not do the mkdir step.

Renamed TPM_DEV to SWTPM_ENABLE. SWTPM_ENABLE is TRUE by default. This enable allows for another user, if they so wish, to use a different TPM in place of the SWTPM by setting SWTPM_ENABLE to FALSE.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built and ran both Q35 and SBSA with TPM enabled. Verified functionality and swtpm created at the build output directory.

## Integration Instructions

N/A