### PR TITLE
Update HAF/TF-A ext dep to v14.0.0

### DIFF
--- a/Platforms/QemuArmVirtPkg/Binaries/haf_tfa_binaries_ext_dep.yaml
+++ b/Platforms/QemuArmVirtPkg/Binaries/haf_tfa_binaries_ext_dep.yaml
@@ -8,10 +8,10 @@ scope: qemuarmvirt
 id: haf-tfa-bin
 type: web
 name: HAF_TFA_BUILD
-source: https://github.com/microsoft/mu_tiano_platforms/releases/download/v12.0.1/haf-tfa-firmware-v12.0.1.zip
+source: https://github.com/microsoft/mu_tiano_platforms/releases/download/v14.0.0/haf-tfa-firmware-v14.0.0.zip
 
-version: v12.0.1
-sha256: 32325a79ab76ab704f84337f0620de60dd4b7dc3d857988a81f85a37ad33f91f
+version: v14.0.0
+sha256: cb138bd733422dcd356b58179db9a508ee87f71959f91b41ecd56bbe191748b1
 internal_path: /
 compression_type: zip
 flags:

--- a/Platforms/QemuArmVirtPkg/PlatformBuild.py
+++ b/Platforms/QemuArmVirtPkg/PlatformBuild.py
@@ -35,7 +35,7 @@ cached_env = os.environ.copy()
 # When the TF-A source code is updated in a way that is not compatible with the existing prebuilts, this should be set
 # to False, which ensures that HAF / TF-A will be build from source if supported. On Windows, TF-A cannot be built from
 # source, so the platform build will be skipped with a warning.
-HAF_TFA_EXTDEP_BINS_CURRENT = False
+HAF_TFA_EXTDEP_BINS_CURRENT = True
 
 # Declare test whose failure will not return a non-zero exit code
 FAILURE_EXEMPT_TESTS = {


### PR DESCRIPTION
## Description

This PR updates the HAF/TF-A external dependency to version v14.0.0.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on QEMU Arm Virt and booted to UEFI shell.

## Integration Instructions

N/A