### PR TITLE
Ci: Force Platform-CI to use windows-2022

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         target: [DEBUG, RELEASE]
         tool-chain: [CLANGPDB, VS2022, GCC5]
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-2022, ubuntu-latest]
         container: ['', '${{ needs.vars.outputs.container-image}}']
         platform: [Q35, ARMVIRT]
         architecture: ['', 'IA32,X64']
@@ -53,7 +53,7 @@ jobs:
 
         exclude:
           # Exclude container builds on Windows
-          - os: windows-latest
+          - os: windows-2022
             container: ${{ needs.vars.outputs.container-image }}
           # Exclude non-container builds on Ubuntu
           - os: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
           # Temporary Filters until only CLANGPDB #
           #########################################
           # Exclude GCC5 builds on Windows
-          - os: windows-latest
+          - os: windows-2022
             tool-chain: GCC5
           # Exclude VS builds on Ubuntu
           - os: ubuntu-latest
@@ -90,7 +90,7 @@ jobs:
           ###########################
           # Exclude Windows, swtpm requires Unix sockets
           - variant: TPM
-            os: windows-latest
+            os: windows-2022
           # Exclude ARMVIRT, no TPM support by default
           - variant: TPM
             platform: ARMVIRT


### PR DESCRIPTION
## Description

Windows-latest has moved to providing VS2026.
Windows-2022 still contains VS2022.

mu_basecore does not yet have the tools_def.template changes required for VS2026 support. 

To unblock PRs into mu_tiano_platforms, make platform-CI run on windows-2022 container image.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Forked branch CI testing.

## Integration Instructions
No integration necessary. 