### PR TITLE
QemuRunner: Manage swtpm as a subprocess and wait for its socket

### DIFF
--- a/Platforms/QemuArmVirtPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuArmVirtPkg/Plugins/QemuRunner/QemuRunner.py
@@ -11,7 +11,8 @@ import io
 import os
 import re
 import datetime
-import threading
+import subprocess
+import time
 from pathlib import Path
 from edk2toolext.environment.plugintypes import uefi_helper_plugin
 from edk2toollib import utility_functions
@@ -45,16 +46,33 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
 
     @staticmethod
-    def RunSwTpmThread(tpm_dir, tpm_sock):
-        """Runs SWTPM in a separate thread"""
-        tpm_cmd = "swtpm"
-        tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
+    def StartSwTpm(tpm_dir, tpm_sock):
+        """Starts the swtpm emulator and returns its Popen handle.
 
-        # Start the TPM emulator in a separate thread
-        ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
-        if ret != 0:
-            logging.critical("Failed to start SWTPM emulator.")
+        swtpm is a long-lived daemon, so it is launched directly with Popen
+        (rather than a blocking helper run in a thread) to keep a handle for
+        explicit teardown.
+        """
+        cmd = [
+            "swtpm", "socket",
+            "--tpmstate", f"dir={tpm_dir}",
+            "--ctrl", f"type=unixio,path={tpm_sock}",
+            "--tpm2",
+            "--log", "level=1",
+        ]
+        return subprocess.Popen(cmd)
+
+    @staticmethod
+    def StopSwTpm(swtpm_proc):
+        """Terminates the swtpm subprocess if it is still running."""
+        if swtpm_proc is None or swtpm_proc.poll() is not None:
             return
+        swtpm_proc.terminate()
+        try:
+            swtpm_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logging.warning("swtpm did not exit after terminate. Killing it.")
+            swtpm_proc.kill()
 
 
     @staticmethod
@@ -122,7 +140,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += " -drive if=pflash,format=raw,unit=1,file=" + \
                 code_fd + ",readonly=on"
 
-        sw_tpm_thread = None
+        swtpm_proc = None
         sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "TRUE")
         if os.name == 'nt':
             sw_tpm_enable = "FALSE"
@@ -133,9 +151,22 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -tpmdev emulator,id=tpm0,chardev=chrtpm"
             args += " -device tpm-tis-device,tpmdev=tpm0"
 
-            logging.info("Starting TPM emulator in a different thread.")
-            sw_tpm_thread = threading.Thread(target=QemuRunner.RunSwTpmThread, args=(tpm_dir, tpm_sock))
-            sw_tpm_thread.start()
+            logging.info("Starting swtpm emulator.")
+            swtpm_proc = QemuRunner.StartSwTpm(tpm_dir, tpm_sock)
+
+            # Wait for swtpm to create the control socket before launching QEMU.
+            # Otherwise QEMU may try to connect before the socket exists and fail.
+            tpm_sock_timeout = 30
+            tpm_sock_poll_start = time.monotonic()
+            while not os.path.exists(tpm_sock):
+                if swtpm_proc.poll() is not None:
+                    logging.critical("swtpm exited before creating its socket.")
+                    return -1
+                if time.monotonic() - tpm_sock_poll_start > tpm_sock_timeout:
+                    logging.critical(f"Timed out waiting for swtpm socket at {tpm_sock}.")
+                    QemuRunner.StopSwTpm(swtpm_proc)
+                    return -1
+                time.sleep(0.1)
 
         # Add XHCI USB controller and mouse
         args += " -device qemu-xhci,id=usb"
@@ -184,7 +215,10 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
                 std_handle = None
 
         # Run QEMU
-        ret = utility_functions.RunCmd(executable, args)
+        try:
+            ret = utility_functions.RunCmd(executable, args)
+        finally:
+            QemuRunner.StopSwTpm(swtpm_proc)
 
         ## TODO: restore the customized RunCmd once unit tests with asserts are figured out
         if ret == 0xc0000005:
@@ -202,8 +236,5 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         elif os.name != 'nt':
             # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway
             utility_functions.RunCmd('stty', 'sane', capture=False)
-
-        if sw_tpm_thread is not None:
-            sw_tpm_thread.join()
 
         return ret

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -12,8 +12,9 @@ import datetime
 import re
 import io
 import shutil
+import subprocess
+import time
 from pathlib import Path
-import threading
 from edk2toolext.environment.plugintypes import uefi_helper_plugin
 from edk2toollib import utility_functions
 
@@ -48,16 +49,33 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
 
     @staticmethod
-    def RunSwTpmThread(tpm_dir, tpm_sock):
-        """Runs SWTPM in a separate thread"""
-        tpm_cmd = "swtpm"
-        tpm_args = f"socket --tpmstate dir={tpm_dir} --ctrl type=unixio,path={tpm_sock} --tpm2 --log level=1"
+    def StartSwTpm(tpm_dir, tpm_sock):
+        """Starts the swtpm emulator and returns its Popen handle.
 
-        # Start the TPM emulator in a separate thread
-        ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
-        if ret != 0:
-            logging.critical("Failed to start SWTPM emulator.")
+        swtpm is a long-lived daemon, so it is launched directly with Popen
+        (rather than a blocking helper run in a thread) to keep a handle for
+        explicit teardown.
+        """
+        cmd = [
+            "swtpm", "socket",
+            "--tpmstate", f"dir={tpm_dir}",
+            "--ctrl", f"type=unixio,path={tpm_sock}",
+            "--tpm2",
+            "--log", "level=1",
+        ]
+        return subprocess.Popen(cmd)
+
+    @staticmethod
+    def StopSwTpm(swtpm_proc):
+        """Terminates the swtpm subprocess if it is still running."""
+        if swtpm_proc is None or swtpm_proc.poll() is not None:
             return
+        swtpm_proc.terminate()
+        try:
+            swtpm_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logging.warning("swtpm did not exit after terminate. Killing it.")
+            swtpm_proc.kill()
 
     @staticmethod
     def Runner(env):
@@ -212,7 +230,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         args += f" -smbios type=1,manufacturer=Palindrome,product=\"QEMU Q35\",family=QEMU,version=\"{'.'.join(qemu_version)}\",serial=42-42-42-42,uuid=9de555c0-05d7-4aa1-84ab-bb511e3a8bef"
         args += f" -smbios type=3,manufacturer=Palindrome,serial=40-41-42-43{boot_selection}"
 
-        sw_tpm_thread = None
+        swtpm_proc = None
         sw_tpm_enable = env.GetValue("SWTPM_ENABLE", "TRUE")
         if os.name == 'nt':
             sw_tpm_enable = "FALSE"
@@ -223,9 +241,22 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             args += " -tpmdev emulator,id=tpm0,chardev=chrtpm"
             args += " -device tpm-tis,tpmdev=tpm0"
 
-            logging.info("Starting TPM emulator in a different thread.")
-            sw_tpm_thread = threading.Thread(target=QemuRunner.RunSwTpmThread, args=(tpm_dir, tpm_sock))
-            sw_tpm_thread.start()
+            logging.info("Starting swtpm emulator.")
+            swtpm_proc = QemuRunner.StartSwTpm(tpm_dir, tpm_sock)
+
+            # Wait for swtpm to create the control socket before launching QEMU.
+            # Otherwise QEMU may try to connect before the socket exists and fail.
+            tpm_sock_timeout = 30
+            tpm_sock_poll_start = time.monotonic()
+            while not os.path.exists(tpm_sock):
+                if swtpm_proc.poll() is not None:
+                    logging.critical("swtpm exited before creating its socket.")
+                    return -1
+                if time.monotonic() - tpm_sock_poll_start > tpm_sock_timeout:
+                    logging.critical(f"Timed out waiting for swtpm socket at {tpm_sock}.")
+                    QemuRunner.StopSwTpm(swtpm_proc)
+                    return -1
+                time.sleep(0.1)
 
         if (env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):
             args += " -display none"  # no graphics
@@ -264,6 +295,8 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         except KeyboardInterrupt:
             logging.critical("QEMU run interrupted by user (ctrl+c).")
             ret = -1
+        finally:
+            QemuRunner.StopSwTpm(swtpm_proc)
 
         ## TODO: restore the customized RunCmd once unit tests with asserts are figured out
         if ret == 0xc0000005:
@@ -281,8 +314,5 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         elif os.name != 'nt':
             # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway
             utility_functions.RunCmd('stty', 'sane', capture=False)
-
-        if sw_tpm_thread is not None:
-            sw_tpm_thread.join()
 
         return ret


### PR DESCRIPTION
## Description

Makes a few changes to improve stability and robustness of swtpm management.

When a TPM is enabled, the runner starts swtpm and then launches QEMU, which connects to swtpm over a Unix socket. This commit addresses two potential issues.

First, QEMU was started immediately after swtpm with no check that the socket was ready. If swtpm had not yet created the socket before QEMU launch, QEMU failed with "Failed to connect to '...swtpm-sock': No such file or directory".

Second, swtpm was launched by `RunCmd()` inside a Python thread. `RunCmd()` blocks until the process exits, but "swtpm socket" is a long-lived daemon that does not exit on its own, so the thread never finished. The code joined that thread at the end of the run, which could block indefinitely. A thread also gives no handle to the underlying process, so there was no way to stop swtpm or guarantee it was cleaned up from the runner.

Changes:

- Start swtpm with `subprocess.Popen()` and keep the handle, instead of running it through `RunCmd()` in a thread. This gives direct control over the process and avoids the blocking thread join.
- After starting swtpm, poll for the control socket to exist (up to 30s) before launching QEMU, and fail early if swtpm exits or the socket never appears.
- Wrap the QEMU run in `try/finally` so swtpm is always terminated, on success, failure, or exception. `terminate()` is attempted first, then `kill()` if it does not exit within 5 seconds.

This is done for both the Q35 and ArmVirt runners.

---

Note: I saw a `terminate` option for `--ctrl` in swtpm documentation (swtpm will self-terminate when QEMU disconnects) but it was not available in my local swtpm installation (v0.6.3) on Ubuntu 22.04, and although we're using the Ubuntu 24.04 image with swtpm 0.7.3, I think it's okay to just rely on `StopSwTpm()` to terminate it with broader compatibility.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Launch QEMU with swtpm on Ubuntu 22.04 and Ubuntu 24.04 hosts
- Verify swtpm is terminated as expected.

## Integration Instructions

- N/A