### PR TITLE
QemuArmVirtPkg: Route DXE OneCrypto load via MM provider

### DIFF
--- a/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
+++ b/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
@@ -1298,6 +1298,9 @@
   StandaloneMmPkg/Core/StandaloneMmCore.inf {
     <LibraryClasses>
       NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+      # Register the LZMA guided-section handler so the MM core can decompress
+      # and dispatch OneCryptoBin from the dedicated compressed [FV.OneCryptoFv].
+      NULL|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
     <PcdsFixedAtBuild>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
       gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|62500000

--- a/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
+++ b/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
@@ -878,7 +878,7 @@
   #
   # OneCrypto Binary Drivers
   #
-  $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderDxe.inf {
+  $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderDxeFromMm.inf {
     <PcdsPatchableInModule>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8040004F
   }
@@ -886,11 +886,11 @@
     <PcdsPatchableInModule>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8040004F
   }
-  $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf {
+  $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoImageProviderStandaloneMm.inf {
     <PcdsPatchableInModule>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8040004F
   }
-  $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinDxe.inf {
+  $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf {
     <PcdsPatchableInModule>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x8040004F
   }

--- a/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.fdf
+++ b/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.fdf
@@ -515,9 +515,21 @@ READ_LOCK_STATUS   = TRUE
   #
   # OneCrypto StandaloneMM Drivers
   #
+  # Single-copy, Mode B (dedicated compressed FV): the loaders and image
+  # provider live here; OneCryptoBin itself lives in the dedicated, LZMA-wrapped
+  # [FV.OneCryptoFv] below. The MM core decompresses and dispatches OneCryptoBin
+  # from that FV, and the image provider locates it by its well-known container
+  # FILE_GUID to serve the compressed payload to DXE.
+  #
   INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderStandaloneMm.inf
   INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoImageProviderStandaloneMm.inf
-  INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf
+
+  # Dedicated, identity-tagged, LZMA-compressed OneCrypto FV (ONE_CRYPTO_CONTAINER_FV_GUID).
+  FILE FV_IMAGE = 1DC82EA3-D1E9-4C10-A788-335D166E23A1 {
+    SECTION GUIDED EE4E5898-3914-4259-9D6E-DC7BD79403CF PROCESSING_REQUIRED = TRUE {
+      SECTION FV_IMAGE = OneCryptoFv
+    }
+  }
 
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -526,6 +538,30 @@ READ_LOCK_STATUS   = TRUE
 !if $(TPM2_ENABLE) == TRUE
   INF SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.inf
 !endif
+
+[FV.OneCryptoFv]
+# Dedicated OneCrypto firmware volume (single stored copy). LZMA-wrapped and
+# anchored in [FV.FV_STANDALONE_MM_COMPACT] by ONE_CRYPTO_CONTAINER_FV_GUID. The
+# MM core decompresses and dispatches OneCryptoBin from here; the image provider
+# serves the same compressed payload to DXE.
+FvAlignment        = 16
+ERASE_POLARITY     = 1
+MEMORY_MAPPED      = TRUE
+STICKY_WRITE       = TRUE
+LOCK_CAP           = TRUE
+LOCK_STATUS        = TRUE
+WRITE_DISABLED_CAP = TRUE
+WRITE_ENABLED_CAP  = TRUE
+WRITE_STATUS       = TRUE
+WRITE_LOCK_CAP     = TRUE
+WRITE_LOCK_STATUS  = TRUE
+READ_DISABLED_CAP  = TRUE
+READ_ENABLED_CAP   = TRUE
+READ_STATUS        = TRUE
+READ_LOCK_CAP      = TRUE
+READ_LOCK_STATUS   = TRUE
+
+  INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf
 
 ################################################################################
 #

--- a/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.fdf
+++ b/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.fdf
@@ -225,8 +225,7 @@ READ_LOCK_STATUS   = TRUE
   #
   # OneCrypto DXE Driver
   #
-  INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderDxe.inf
-  INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinDxe.inf
+  INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderDxeFromMm.inf
   
   #
   # Multiple Console IO support
@@ -517,6 +516,7 @@ READ_LOCK_STATUS   = TRUE
   # OneCrypto StandaloneMM Drivers
   #
   INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoLoaderStandaloneMm.inf
+  INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoLoaders/OneCryptoImageProviderStandaloneMm.inf
   INF $(ONE_CRYPTO_PATH)/$(TARGET)/AARCH64/OneCryptoBin/OneCryptoBinStandaloneMm.inf
 
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf

--- a/Platforms/QemuArmVirtPkg/fdts/qemu_virt_mssp_rust_config.dts
+++ b/Platforms/QemuArmVirtPkg/fdts/qemu_virt_mssp_rust_config.dts
@@ -35,7 +35,7 @@
 	execution-state = <0>; /* AArch64*/
 	load-address = <0x0 0x0e700000>;
 	entrypoint-offset = <0x2000>;
-	image-size = <0x0 0x400000>;
+	image-size = <0x0 0x80000>;
 	xlat-granule = <0>; /* 4KiB */
 	boot-order = <2>;
 	messaging-method = <0x603>; /* Direct request/response supported. */

--- a/Platforms/QemuArmVirtPkg/fdts/qemu_virt_spmc_sp_manifest.dts
+++ b/Platforms/QemuArmVirtPkg/fdts/qemu_virt_spmc_sp_manifest.dts
@@ -35,7 +35,7 @@
        load_address = <0x0 0x0e700000>;
        debug_name = "mssp-rust";
        vcpu_count = <1>;
-       mem_size = <0x400000>;
+       mem_size = <0x80000>;
      };
    };
 

--- a/Platforms/QemuArmVirtPkg/fdts/qemu_virt_stmm_config.dts
+++ b/Platforms/QemuArmVirtPkg/fdts/qemu_virt_stmm_config.dts
@@ -87,8 +87,8 @@
 			 * heap buffer.
 			 */
 			description = "heap";
-			base-address = <0x0 0x0EB00000>;
-			pages-count = <0x3ff>;
+			base-address = <0x0 0x0E780000>;
+			pages-count = <0x77f>;
 			attributes = <0x3>;
 		};
 


### PR DESCRIPTION
📌https://github.com/microsoft/mu_crypto_release/pull/264
📌https://github.com/microsoft/mu_basecore/pull/1877

## Description

Remove the DXE OneCrypto binary from FvMain and add OneCryptoImageProviderStandaloneMm to the
StandaloneMM FV.

This keeps OneCrypto resident in secure world and has DXE fetch the image over MM communication via
the existing loader path.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

QemuArmVirtPkg locally, and a physical platform to validate this works.

## Integration Instructions

For platforms, review the changes in this PR to see how to adopt a single copy of OneCrypto