### PR TITLE
QemuQ35, QemuArmVirt: Remove FILEALIGN directives in dsc files

### DIFF
--- a/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
+++ b/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
@@ -1395,7 +1395,7 @@
 !endif
 
 [BuildOptions.common.EDKII.SEC,BuildOptions.common.EDKII.MM_CORE_STANDALONE]
-  GCC:*_CLANGPDB_*_DLINK_FLAGS = /ALIGN:0x1000 /FILEALIGN:0x1000
+  GCC:*_CLANGPDB_*_DLINK_FLAGS = /ALIGN:0x1000
 
 [BuildOptions.common.EDKII.DXE_CORE,BuildOptions.common.EDKII.DXE_DRIVER,BuildOptions.common.EDKII.UEFI_DRIVER,BuildOptions.common.EDKII.UEFI_APPLICATION,BuildOptions.common.EDKII.MM_CORE_STANDALONE,BuildOptions.common.EDKII.MM_STANDALONE]
   GCC:*_GCC5_*_DLINK_FLAGS = -z common-page-size=0x1000

--- a/Platforms/QemuQ35Pkg/QemuQ35PkgX64.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35PkgX64.dsc
@@ -57,7 +57,7 @@
 
   MSFT:*_*_*_DLINK_FLAGS = /ALIGN:64
   GCC:*_GCC5_*_DLINK_FLAGS = -z common-page-size=64
-  GCC:*_CLANGPDB_*_DLINK_FLAGS = /ALIGN:64 /FILEALIGN:64
+  GCC:*_CLANGPDB_*_DLINK_FLAGS = /ALIGN:64
 
 # Force PE/COFF sections to be aligned at 4KB boundaries to support page level
 # protection of DXE_SMM_DRIVER/SMM_CORE modules


### PR DESCRIPTION

## Description

The FILEALIGN directives force generation of a large PE image size by ensuring section alignment in the generated image.

This is different from the ALIGN directive, which will say that PE images loaded need to meet a specific alignment boundry.

Remove the FILEALIGN so that smaller PE images are generated.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Compilation with 4k aligned images in build_rule.template resulted in 
FV size issues. Removing these directives reduced the overall space
required.

## Integration Instructions
No integration necessary.