### PR TITLE
QemuArmVirtPkg: Use FILEALIGN for CLANGPDB/GCC StandaloneMmCore [Rebase & FF]

### DIFF
--- a/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
+++ b/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
@@ -1395,7 +1395,12 @@
 !endif
 
 [BuildOptions.common.EDKII.SEC,BuildOptions.common.EDKII.MM_CORE_STANDALONE]
-  GCC:*_CLANGPDB_*_DLINK_FLAGS = /ALIGN:0x1000
+  # DLINK_XIPFLAGS (which pairs FILEALIGN with ALIGN for CLANGPDB XIP rebasing) is only used in build_rule.template
+  # for SEC/PEI_CORE/PEIM module types. MM_CORE_STANDALONE is packaged as FFS type SEC in QemuArmVirtPkg's
+  # Rule.Common.MM_CORE_STANDALONE. This causes it to be rebased by GenFv the same way SEC is, and therefore also needs
+  # FileAlignment == SectionAlignment. This sets /FILEALIGN here explicitly. Not needed in QemuQ35Pkg because
+  # [Rule.Common.MM_CORE_STANDALONE] specifies the FFS type as MM_CORE_STANDALONE there.
+  GCC:*_CLANGPDB_*_DLINK_FLAGS = /ALIGN:0x1000 /FILEALIGN:0x1000
 
 [BuildOptions.common.EDKII.DXE_CORE,BuildOptions.common.EDKII.DXE_DRIVER,BuildOptions.common.EDKII.UEFI_DRIVER,BuildOptions.common.EDKII.UEFI_APPLICATION,BuildOptions.common.EDKII.MM_CORE_STANDALONE,BuildOptions.common.EDKII.MM_STANDALONE]
   GCC:*_GCC5_*_DLINK_FLAGS = -z common-page-size=0x1000


### PR DESCRIPTION
## Description

GenFv fails to rebase StandaloneMmCore.efi in `FV_STANDALONE_MM_COMPACT` with: "PE image Section-Alignment and File-Alignment do not match".

mu_basecore commit `347ac898` forces 4K section alignment for AARCH64 CLANGPDB modules, but build_rule.template only pairs it with a matching `FILEALIGN` for SEC/PEI_CORE/PEIM:

`[Static-Library-File.SEC, Static-Library-File.PEI_CORE, Static-Library-File.PEIM]`

StandaloneMmCore's `MODULE_TYPE` is `MM_CORE_STANDALONE`, so it misses that pairing, even though this platform's `Rule.Common.MM_CORE_STANDALONE` packages it as FFS type `SEC`, so GenFv rebases it the same way it rebases SEC modules.

mu_tiano_platforms commit `906eb98` removed this `FILEALIGN` directive from both QemuArmVirtPkg and QemuQ35Pkg.

That worked for QemuQ35Pkg, which packages `MM_CORE_STANDALONE` as its own native FFS type and is never rebased by GenFv.

This commit re-adds `/FILEALIGN:0x1000` for `SEC` and `MM_CORE_STANDALONE` modules in QemuArmVirtPkg.

---

Also includes a MU_BASECORE update:

**Bumps MU_BASECORE from `2025110002.0.11` to `2025110002.0.12`**

Introduces 2 new commits in [MU_BASECORE](https://github.com/microsoft/mu_basecore.git).

<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/microsoft/mu_basecore/commit/29d32ac447690388af0d427bb157edff2767dfd6">29d32a</a> [CHERRY-PICK] SecurityPkg: Add Google Test MockSecureBootVariableLib</li>
<li><a href="https://github.com/microsoft/mu_basecore/commit/18de13ad691dbe878db7d62b1139db7a65d4dbb6">18de13</a> [Cherry-Pick] BaseTools: Enable 4k alignment for tool chains</li>
</ul>
</details>

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Failed before & passes after: `stuart_build -c Platforms/QemuArmVirtPkg/PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB TARGET=DEBUG`

## Integration Instructions

- N/A

---

I noticed this in [Patina QEMU PR Validation](https://github.com/microsoft/mu_basecore/actions/runs/29867514656/job/88807064355) after 906eb98. Reproduced locally and put my understanding of the issue in the commit/PR description.