### PR TITLE
Update HAF/TF-A ext dep to v15.0.0 & fix ArmVirt Ubuntu boot [Rebase & FF]

### DIFF
--- a/Platforms/QemuArmVirtPkg/Binaries/haf_tfa_binaries_ext_dep.yaml
+++ b/Platforms/QemuArmVirtPkg/Binaries/haf_tfa_binaries_ext_dep.yaml
@@ -8,10 +8,10 @@ scope: qemuarmvirt
 id: haf-tfa-bin
 type: web
 name: HAF_TFA_BUILD
-source: https://github.com/microsoft/mu_tiano_platforms/releases/download/v14.0.0/haf-tfa-firmware-v14.0.0.zip
+source: https://github.com/microsoft/mu_tiano_platforms/releases/download/v15.0.0/haf-tfa-firmware-v15.0.0.zip
 
-version: v14.0.0
-sha256: cb138bd733422dcd356b58179db9a508ee87f71959f91b41ecd56bbe191748b1
+version: v15.0.0
+sha256: 942199bddeb1080850c5fcc928a840eaf044c41b5381dda0e02a9456343c787b
 internal_path: /
 compression_type: zip
 flags:

--- a/Platforms/QemuArmVirtPkg/PlatformBuild.py
+++ b/Platforms/QemuArmVirtPkg/PlatformBuild.py
@@ -35,7 +35,7 @@ cached_env = os.environ.copy()
 # When the TF-A source code is updated in a way that is not compatible with the existing prebuilts, this should be set
 # to False, which ensures that HAF / TF-A will be build from source if supported. On Windows, TF-A cannot be built from
 # source, so the platform build will be skipped with a warning.
-HAF_TFA_EXTDEP_BINS_CURRENT = True
+HAF_TFA_EXTDEP_BINS_CURRENT = False
 
 # Declare test whose failure will not return a non-zero exit code
 FAILURE_EXEMPT_TESTS = {
@@ -754,7 +754,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         args += " DEBUG=" + str(1 if self.env.GetValue("TARGET").lower() == 'debug' else 0)
         args += " ENABLE_SME_FOR_SWD=0 ENABLE_SVE_FOR_SWD=0 ENABLE_SME_FOR_NS=0 ENABLE_SVE_FOR_NS=0"
         args += f" SPD=spmd SPMD_SPM_AT_SEL2=1 SP_LAYOUT_FILE={filename}"
-        args += " ENABLE_FEAT_HCX=1 HOB_LIST=1 TRANSFER_LIST=1 LOG_LEVEL=40 ENABLE_FEAT_MTE2=2 CTX_INCLUDE_PAUTH_REGS=1 " # Features used by hypervisor
+        args += " ENABLE_FEAT_HCX=1 HOB_LIST=1 TRANSFER_LIST=1 LOG_LEVEL=40 ENABLE_FEAT_MTE2=2 CTX_INCLUDE_PAUTH_REGS=1 ENABLE_FEAT_TCR2=1 ENABLE_FEAT_S1PIE=1" # Features used by hypervisor
         # args += " FEATURE_DETECTION=1" # Enforces support for features enabled.
         args += f" BL32={str(haf_out / 'secure_qemu_aarch64_clang' / 'hafnium.bin')}"
         args += f" PRELOADED_BL33_BASE=0x04000000" # This value matches the QEMU_FLASH1_BASE in platform_def.h

--- a/Platforms/QemuArmVirtPkg/PlatformBuild.py
+++ b/Platforms/QemuArmVirtPkg/PlatformBuild.py
@@ -35,7 +35,7 @@ cached_env = os.environ.copy()
 # When the TF-A source code is updated in a way that is not compatible with the existing prebuilts, this should be set
 # to False, which ensures that HAF / TF-A will be build from source if supported. On Windows, TF-A cannot be built from
 # source, so the platform build will be skipped with a warning.
-HAF_TFA_EXTDEP_BINS_CURRENT = False
+HAF_TFA_EXTDEP_BINS_CURRENT = True
 
 # Declare test whose failure will not return a non-zero exit code
 FAILURE_EXEMPT_TESTS = {
@@ -328,7 +328,7 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
         self.env.SetValue("MU_SCHEMA_DIR", self.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath("QemuArmVirtPkg", "CfgData"), "Platform Defined")
         self.env.SetValue("MU_SCHEMA_FILE_NAME", "QemuArmVirtPkgCfgData.xml", "Platform Hardcoded")
         self.env.SetValue("HAF_TFA_BUILD", "FALSE", "Platform Hardcoded", overridable=True)
-        
+
         # If HAF/TF-A binaries are not in sync, and we are on Windows, exit without building the platform because we
         # cannot compile TF-A on Windows. Otherwise, (if on Linux) we force the build of TF-A to ensure the binaries
         # are in sync.


### PR DESCRIPTION
## Description

Two commits. One to update to the current HAF/TF-A release and the next to prepare for the next release which fixes Ubuntu QEMU v11 boot.

---

**Updates the HAF/TF-A external dependency to latest (v15.0.0).**

Note: Need this to build QemuArmVirtPkg on Windows.

--- 

**[arm-virt] Fix ubuntu boot under QEMU 11**

The nightly ubuntu boot test is failing and caused the system to hang.
This is because the QEMU 11 + cpu max will broadcast the CPU capable of
S1PIE and TCR2 through ID_AA64MMFR3_EL1.

The Linux kernel will attempt to use these registers before the VBAR is
programmed and ran into recursive exceptions:

```
0x59fab870:  msr   pire0_el1, x0
...
0x59fab884:  msr   pir_el1, x0
...
0x59fab88c:  msr   tcr2_el1, x0
```

This change enables these features from TF-A.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QemuArmVirtPkg build and boot to EFI shell

## Integration Instructions

- N/A