### PR TITLE
[dev/PQC] MU_BASECORE: Track dev/202511/post-quantum-staging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "MU_BASECORE"]
 	path = MU_BASECORE
 	url = https://github.com/microsoft/mu_basecore.git
-	branch = release/202511
+	branch = dev/202511/post-quantum-staging
 [submodule "Common/MU"]
 	path = Common/MU
 	url = https://github.com/microsoft/mu_plus.git


### PR DESCRIPTION
## Description

This pull request updates the `MU_BASECORE` submodule to track a new development branch focused on post-quantum staging. This ensures the project is aligned with the latest changes in the upstream repository related to post-quantum cryptography.

Submodule updates:

* Changed the `MU_BASECORE` submodule branch from `release/202511` to `dev/202511/post-quantum-staging` in `.gitmodules` to track the latest development work on post-quantum features.
* Updated the `MU_BASECORE` submodule commit to the latest on the new branch for compatibility and access to recent updates.
For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A