### PR TITLE
Harden the qemu runner output handling to avoid software deadlock

### DIFF
--- a/Platforms/QemuArmVirtPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuArmVirtPkg/Plugins/QemuRunner/QemuRunner.py
@@ -223,7 +223,9 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         # Run QEMU
         try:
-            ret = utility_functions.RunCmd(executable, args)
+            ret = utility_functions.RunCmd(
+                executable, args, encodingErrors="replace"
+            )
         finally:
             QemuRunner.StopSwTpm(swtpm_proc)
 

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -298,7 +298,9 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         # Run QEMU
         try:
-            ret = utility_functions.RunCmd(executable, args)
+            ret = utility_functions.RunCmd(
+                executable, args, encodingErrors="replace"
+            )
         except KeyboardInterrupt:
             logging.critical("QEMU run interrupted by user (ctrl+c).")
             ret = -1


### PR DESCRIPTION
## Description

When QEMU is configured to print serial output through console (stdio), it would write to its debugcon and wait for the launcher to consume it. In our case, it would be the `RunCmd`'s job to spawn up a thread that does this.

In the meantime, our `RunCmd.reader` would read and decode the console output line by line, with the error handling by default. When a decode fails, the decoding exception remains hidden from the main thread. This would leave the QEMU software hanging as the debugcon write will not progress.

This change fixes the decoding handling by setting the `encodingErrors="replace"` to avoid the reader thread exception caused QEMU freeze.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Enable Windows boot manager debugger, prior to the change, the QEMU may or may not freeze. After the change, the console starts to print `Boot Debugger Initialized` as expected.

## Integration Instructions

N/A